### PR TITLE
ci(mirror-sync): use GITHUB_TOKEN instead of CROSS_REPO_PAT

### DIFF
--- a/.github/workflows/mirror-sync.yaml
+++ b/.github/workflows/mirror-sync.yaml
@@ -70,7 +70,9 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: true
-          token: ${{ secrets.CROSS_REPO_PAT }}
+          # GITHUB_TOKEN (not a PAT) is enough: we only push refs within
+          # this same repo, and the job's `permissions: contents: write`
+          # block below grants exactly that.
 
       - name: Configure bot identity
         run: |


### PR DESCRIPTION
## Summary

Symmetric to k8sstormcenter/storage#13.

Mirror-sync only writes refs inside this repo (\`refs/heads/test-mirror/**\`), so it doesn't need a cross-repo PAT. The job's existing \`permissions: contents: write\` block gives \`GITHUB_TOKEN\` write access to refs. Drops \`token: \${{ secrets.CROSS_REPO_PAT }}\` on the checkout step so it falls back to \`GITHUB_TOKEN\`.

## Why

This fork's mirror-sync happens to work today — its \`CROSS_REPO_PAT\` has the right permissions. But the storage fork's equivalent secret is missing Contents: Write and the workflow 403'd there. Rather than normalise PAT scopes across forks, drop the PAT dependency entirely: GITHUB_TOKEN is scoped per-run by this workflow's own \`permissions:\` block, so there's nothing to drift.

Keeps the two forks' mirror-sync workflows byte-identical again (single mental model).

## Test plan

- [ ] Merge
- [ ] \`gh workflow run mirror-sync.yaml --repo k8sstormcenter/node-agent --ref main -f source_branch=upstream-pr/analyzer-zero-alloc\`
- [ ] Confirm \`test-mirror/upstream-pr/analyzer-zero-alloc\` is still created/updated successfully (it was at 6e5ec9c5 before this change)