### PR TITLE
tests(component): restore Related{Kind,Name,Namespace}MetadataKey rename

### DIFF
--- a/tests/component_test.go
+++ b/tests/component_test.go
@@ -2211,9 +2211,9 @@ func Test_28_UserDefinedNetworkNeighborhood(t *testing.T) {
 				Labels: map[string]string{
 					helpersv1.ApiGroupMetadataKey:   "apps",
 					helpersv1.ApiVersionMetadataKey: "v1",
-					helpersv1.KindMetadataKey:       "Deployment",
-					helpersv1.NameMetadataKey:       "curl-28",
-					helpersv1.NamespaceMetadataKey:  ns.Name,
+					helpersv1.RelatedKindMetadataKey:       "Deployment",
+					helpersv1.RelatedNameMetadataKey:       "curl-28",
+					helpersv1.RelatedNamespaceMetadataKey:  ns.Name,
 				},
 			},
 			Spec: v1beta1.NetworkNeighborhoodSpec{
@@ -2836,8 +2836,8 @@ func Test_30_TamperedSignedProfiles(t *testing.T) {
 					helpersv1.CompletionMetadataKey: helpersv1.Full,
 				},
 				Labels: map[string]string{
-					helpersv1.KindMetadataKey: "Deployment",
-					helpersv1.NameMetadataKey: "tamper-test",
+					helpersv1.RelatedKindMetadataKey: "Deployment",
+					helpersv1.RelatedNameMetadataKey: "tamper-test",
 				},
 			},
 			Spec: v1beta1.NetworkNeighborhoodSpec{


### PR DESCRIPTION
Cherry-pick of 48e52be0 — the rename was lost during the upstream merge that produced 99b1bf43. All component tests on main currently fail with `undefined: helpersv1.KindMetadataKey` because tests/component_test.go references the old names while go.mod pulls k8s-interface v0.0.206 which only has the `Related*` variants.

5 occurrences renamed in tests/component_test.go. `go vet -tags=component ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)