### PR TITLE
ci(benchmark): query upstream releases for the baseline image

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -57,10 +57,13 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # Baseline = latest UPSTREAM release. Our fork doesn't tag releases,
+          # so querying ${{ github.repository }} gives 404. Comparing against
+          # upstream is also the meaningful baseline for performance work.
           if [[ -n "${{ inputs.before_image }}" ]]; then
             echo "BEFORE_IMAGE=${{ inputs.before_image }}" >> "$GITHUB_OUTPUT"
           else
-            LATEST_TAG=$(gh api repos/${{ github.repository }}/releases/latest --jq '.tag_name')
+            LATEST_TAG=$(gh api repos/kubescape/node-agent/releases/latest --jq '.tag_name')
             echo "BEFORE_IMAGE=quay.io/kubescape/node-agent:${LATEST_TAG}" >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
## Summary

The Performance Benchmark workflow aborts at the `Resolve before image` step because it calls `gh api repos/k8sstormcenter/node-agent/releases/latest` and our fork has no GitHub releases — returns 404.

The next line of the same step already constructs the baseline as `quay.io/kubescape/node-agent:${LATEST_TAG}` (upstream registry), so querying upstream's releases endpoint to get the tag is consistent with how the image is then resolved. It also gives us a meaningful 'us vs latest upstream release' comparison.

## Test plan

- [ ] Workflow run on this branch reaches the `Build after image` step (no longer aborts at `Resolve before image`)
- [ ] `Quality gate` step finds before/after metrics and runs to completion
- [ ] Markdown report is generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)