### PR TITLE
deps(storage): pick up wildcard-port contamination fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -507,4 +507,4 @@ replace github.com/inspektor-gadget/inspektor-gadget => github.com/matthyx/inspe
 
 replace github.com/cilium/ebpf => github.com/matthyx/ebpf v0.0.0-20260421101317-8a32d06def6c
 
-replace github.com/kubescape/storage => github.com/k8sstormcenter/storage v0.0.240-0.20260426191622-cdbf491b5bd8
+replace github.com/kubescape/storage => github.com/k8sstormcenter/storage v0.0.240-0.20260429052903-0e0366026f05

--- a/go.sum
+++ b/go.sum
@@ -981,8 +981,8 @@ github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHm
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
-github.com/k8sstormcenter/storage v0.0.240-0.20260426191622-cdbf491b5bd8 h1:T39tWgm8ur/a4Y3D7GJ1CLKIl9xMCSC1bBNPKQfKDCM=
-github.com/k8sstormcenter/storage v0.0.240-0.20260426191622-cdbf491b5bd8/go.mod h1:amdg/Qok9bqPzs1vZH5FW9/3MbCawc5wVsz9u3uIfu4=
+github.com/k8sstormcenter/storage v0.0.240-0.20260429052903-0e0366026f05 h1:RCEcduxCntYAuo8BleZu84Kk//X0gvsGrutQtdcLMn0=
+github.com/k8sstormcenter/storage v0.0.240-0.20260429052903-0e0366026f05/go.mod h1:amdg/Qok9bqPzs1vZH5FW9/3MbCawc5wVsz9u3uIfu4=
 github.com/kastenhq/goversion v0.0.0-20230811215019-93b2f8823953 h1:WdAeg/imY2JFPc/9CST4bZ80nNJbiBFCAdSZCSgrS5Y=
 github.com/kastenhq/goversion v0.0.0-20230811215019-93b2f8823953/go.mod h1:6o+UrvuZWc4UTyBhQf0LGjW9Ld7qJxLz/OqvSOWWlEc=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=


### PR DESCRIPTION
## Summary
- Bumps the `replace` directive on `kubescape/storage` to commit `0e036602` from k8sstormcenter/storage#21.
- That fix prevents a single `:0` (wildcard-port) entry in the endpoint slice from over-broadening unrelated concrete-port endpoints (flagged on upstream kubescape/storage#316).
- Sibling branch named identically to the storage PR so matrix CI can validate the fix end-to-end before either side merges.

## Test plan
- [ ] node-agent component tests pass against the new storage commit
- [ ] Performance Benchmark — no allocation regression
- [ ] Storage Manual Integration Tests pass on the matching `fix/endpoint-wildcard-port-overbroaden` branch in storage

🤖 Generated with [Claude Code](https://claude.com/claude-code)