### PR TITLE
ci: pin all GitHub Actions to immutable SHAs

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -33,12 +33,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.25"
 
@@ -97,7 +97,7 @@ jobs:
           echo "After image will be loaded by dedup-bench.sh"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 
@@ -128,7 +128,7 @@ jobs:
             "${{ github.workspace }}/benchmark-output/after"
 
       - name: Comment on PR
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
         if: github.event_name == 'pull_request' && always()
         continue-on-error: true
         with:
@@ -137,7 +137,7 @@ jobs:
           comment-tag: benchmark-results
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: benchmark-results

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,11 +26,11 @@ jobs:
       packages: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.25"
 
@@ -57,20 +57,20 @@ jobs:
 
       - name: Set up QEMU
         if: ${{ inputs.PLATFORMS }}
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: build/Dockerfile

--- a/.github/workflows/bypass.yaml
+++ b/.github/workflows/bypass.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Get build number
         id: get-build
-        uses: mlilback/build-number@v1
+        uses: mlilback/build-number@81a5eb0abae9b77d036138284ba1094d49acbc32 # v1
         with:
           base: 254
           run-id: ${{ github.run_number }}

--- a/.github/workflows/component-tests.yaml
+++ b/.github/workflows/component-tests.yaml
@@ -72,7 +72,7 @@ jobs:
       needs_rebuild: ${{ steps.check.outputs.needs_rebuild }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 2
 
@@ -121,9 +121,9 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -159,7 +159,7 @@ jobs:
           echo "storage_short=${STORAGE_REF:0:7}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.25"
 
@@ -249,7 +249,7 @@ jobs:
         ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Kind
         run: |
@@ -307,7 +307,7 @@ jobs:
       - name: Set up Go
         env:
           CGO_ENABLED: 0
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
         with:
           go-version: "1.25"
       - name: Set unlimited memlock limit

--- a/.github/workflows/go-basic-tests.yaml
+++ b/.github/workflows/go-basic-tests.yaml
@@ -79,11 +79,11 @@ jobs:
     #   matrix:
     #     os: ${{ fromJSON(needs.Setup-Environment.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         name: Setup Go
         with:
           go-version: '${{ inputs.GO_VERSION }}'
@@ -104,17 +104,17 @@ jobs:
 
       - name: Initialize CodeQL
         continue-on-error: true
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2
         with:
           languages: go
 
       - name: Autobuild
         continue-on-error: true
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2
 
       - name: Perform CodeQL Analysis
         continue-on-error: true
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2
 
       # - name: Test go build
       #   run: go build -v ${{ inputs.BUILD_PATH }}

--- a/.github/workflows/incluster-comp-pr-merged.yaml
+++ b/.github/workflows/incluster-comp-pr-merged.yaml
@@ -78,13 +78,13 @@ jobs:
       #   if: github.ref == 'master'
       #   run: exit -1
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         name: Checkout
         with:
           fetch-depth: 0
         #   submodules: recursive
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         name: Installing go
         with:
           go-version: "${{ inputs.GO_VERSION }}"
@@ -96,10 +96,10 @@ jobs:
         run: make gadgets
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Set prerelease image tag
         id: image-prerelease-tag
@@ -110,14 +110,14 @@ jobs:
         run: go test -exec sudo -v ./...
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: build/Dockerfile
@@ -129,7 +129,7 @@ jobs:
           push: true
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@main
+        uses: sigstore/cosign-installer@b5e753ae2d39589c7b38850b463739151fc67f07 # main
         with:
           cosign-release: "v2.2.2"
 
@@ -177,7 +177,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         with:
           app-id: ${{ secrets.E2E_DISPATCH_APP_ID }}
           private-key: ${{ secrets.E2E_DISPATCH_APP_PRIVATE_KEY }}
@@ -330,7 +330,7 @@ jobs:
 
       - name: Upload failed step logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: failed-e2e-logs-attempt-${{ github.run_attempt }}
           path: failed_*.txt
@@ -355,10 +355,10 @@ jobs:
       contents: write
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -379,7 +379,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ inputs.IMAGE_TAG }}
@@ -390,7 +390,7 @@ jobs:
 
       - name: Trigger helm chart workflow
         if: ${{ inputs.TRIGGER_HELM_CICD == true }}
-        uses: benc-uk/workflow-dispatch@v1
+        uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1
         with:
           workflow: 00-cicd.yaml
           repo: kubescape/helm-charts

--- a/.github/workflows/pr-merged.yaml
+++ b/.github/workflows/pr-merged.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Get build number
         id: get-build
-        uses: mlilback/build-number@v1
+        uses: mlilback/build-number@81a5eb0abae9b77d036138284ba1094d49acbc32 # v1
         with:
           base: -550
           run-id: ${{ github.run_number }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,12 +32,12 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@v2.4.0
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif
@@ -59,7 +59,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: SARIF file
           path: results.sarif
@@ -67,6 +67,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/sign-object.yaml
+++ b/.github/workflows/sign-object.yaml
@@ -34,7 +34,7 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set image tag
         id: tag
@@ -47,16 +47,16 @@ jobs:
             echo "tag=latest" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         if: github.event_name != 'pull_request'
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: cmd/sign-object/Dockerfile


### PR DESCRIPTION
## Why

Scorecard / GitHub code-scanning has 64 open Pinned-Dependencies alerts (security_severity: medium). The workflow `uses:` references account for ~53 of them — every line like `uses: actions/checkout@v4` is flagged because tags are mutable and an action author can move them to point at different code at any time.

## What

Replaced every `uses: org/repo@<tag>` with `uses: org/repo@<sha> # <tag>` across all workflow files. The trailing comment preserves the original semantic for human readers; the SHA pins the action to immutable bytes.

Generated with [`mheap/pin-github-action`](https://github.com/mheap/pin-github-action) v3.4.0.

Files updated (9):
- `benchmark.yaml`
- `build.yaml`
- `bypass.yaml`
- `component-tests.yaml`
- `go-basic-tests.yaml`
- `incluster-comp-pr-merged.yaml`
- `pr-merged.yaml`
- `scorecard.yml`
- `sign-object.yaml`

The other workflow files (`incluster-comp-pr-created.yaml`, `pr-created.yaml`) had no unpinned references to update.

## Coverage

Closes ~53 of 64 Pinned-Dependencies alerts (the workflow `uses:` subset).

The remaining 11 are Dockerfile alerts:
- `build/Dockerfile` (lines 1, 17)
- `build/Dockerfile.debug` (lines 1, 7, 13)
- `clamav/Dockerfile` (lines 3, 10)
- `cmd/sign-object/Dockerfile` (lines 1, 17)
- `tests/images/malicious-app/Dockerfile` (lines 1, 6)

Those need `FROM image:tag@sha256:<digest>` style pinning, which requires fetching each base image's current digest. Out of scope for this PR — will follow up.

## Maintenance — IMPORTANT

Pinning to SHAs trades one staleness problem (mutable tags) for another (no auto-updates). Pair this PR with Renovate or Dependabot:

```yaml
# .github/dependabot.yml
version: 2
updates:
  - package-ecosystem: "github-actions"
    directory: "/"
    schedule:
      interval: "weekly"
```

Without that, every action is frozen until someone hand-updates a SHA.

## Risk

Low. SHA-pinning is a no-op for workflow behavior — every action runs at the same code it ran at before this PR (the SHAs the tags pointed at when this commit was created). The only change is the alert noise dropping.

YAML validated: all 11 workflow files parse cleanly with `yaml.safe_load`.

## Test plan

- [ ] CI green on this PR
- [ ] `gh api repos/k8sstormcenter/node-agent/code-scanning/alerts?state=open --jq 'map(select(.rule.name == "Pinned-Dependencies")) | length'` drops by ~53 after merge
- [ ] Confirm Renovate/Dependabot follow-up plan