### PR TITLE
gadget(trace_open): resolve relative opens against dirfd/cwd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,15 @@ DOCKERFILE_PATH=./build/Dockerfile
 BINARY_NAME=node-agent
 
 IMAGE?=quay.io/kubescape/$(BINARY_NAME)
-GADGETS=advise_seccomp trace_capabilities trace_dns trace_exec trace_open
+# GADGETS are pulled unmodified from upstream IG. trace_open is intentionally NOT
+# here: it is vendored and built from source (see BUILT_GADGETS) so the fpath
+# resolver can resolve relative opens against their dirfd/cwd.
+GADGETS=advise_seccomp trace_capabilities trace_dns trace_exec
 VERSION=v0.48.1
 KUBESCAPE_GADGETS=bpf exit fork hardlink http iouring_new iouring_old kmod network ptrace randomx ssh symlink unshare
+# BUILT_GADGETS are vendored under pkg/ebpf/gadgets and built under their full
+# upstream image name+tag so node-agent's pinned openImageName keeps resolving.
+BUILT_GADGETS=trace_open
 TAG?=test
 # TAG?=v0.0.1
 
@@ -26,5 +32,6 @@ docker-push: docker-build
 
 gadgets:
 	$(foreach img,$(KUBESCAPE_GADGETS),$(MAKE) -C ./pkg/ebpf/gadgets/$(img) build IMAGE=$(img) TAG=latest;)
+	$(foreach img,$(BUILT_GADGETS),$(MAKE) -C ./pkg/ebpf/gadgets/$(img) build IMAGE=ghcr.io/inspektor-gadget/gadget/$(img) TAG=$(VERSION);)
 	$(foreach img,$(GADGETS),sudo ig image pull ghcr.io/inspektor-gadget/gadget/$(img):$(VERSION);)
-	sudo ig image export $(foreach img,$(GADGETS),ghcr.io/inspektor-gadget/gadget/$(img):$(VERSION)) $(foreach img,$(KUBESCAPE_GADGETS),$(img):latest) tracers.tar
+	sudo ig image export $(foreach img,$(GADGETS) $(BUILT_GADGETS),ghcr.io/inspektor-gadget/gadget/$(img):$(VERSION)) $(foreach img,$(KUBESCAPE_GADGETS),$(img):latest) tracers.tar

--- a/pkg/ebpf/gadgets/trace_open/Makefile
+++ b/pkg/ebpf/gadgets/trace_open/Makefile
@@ -1,0 +1,13 @@
+# trace_open is vendored (not pulled from upstream IG) so the fpath resolver can
+# resolve relative opens against their dirfd/cwd — see program.bpf.c. Built under
+# the same image name node-agent already pins in open.go, so nothing else changes.
+IMAGE?=ghcr.io/inspektor-gadget/gadget/trace_open
+TAG?=v0.48.1
+
+build:
+	sudo TMPDIR=$$TMPDIR ig image build -t $(IMAGE):$(TAG) . --update-metadata
+
+run:
+	sudo ig run $(IMAGE):$(TAG) --verify-image=false -o jsonpretty
+
+build-and-run: build run

--- a/pkg/ebpf/gadgets/trace_open/Makefile
+++ b/pkg/ebpf/gadgets/trace_open/Makefile
@@ -1,11 +1,17 @@
 # trace_open is vendored (not pulled from upstream IG) so the fpath resolver can
-# resolve relative opens against their dirfd/cwd — see program.bpf.c. Built under
+# resolve relative opens against their dirfd/cwd -- see program.bpf.c. Built under
 # the same image name node-agent already pins in open.go, so nothing else changes.
 IMAGE?=ghcr.io/inspektor-gadget/gadget/trace_open
 TAG?=v0.48.1
 
+# Pin the builder to the v0.48.1 default so the vendored source (authored against
+# v0.48.1 gadget headers) compiles the same way regardless of which ig CLI the
+# caller has installed. A newer builder's gadget_get_user_stack macro rejects the
+# v0.48.1 syscall_trace_exit ctx type; pinning keeps the build reproducible.
+BUILDER_IMAGE?=ghcr.io/inspektor-gadget/gadget-builder@sha256:e0e88543a99bbc4b1263b7f9d07a08fb8f1107426525ef8b777bdd8df15d1ee8
+
 build:
-	sudo TMPDIR=$$TMPDIR ig image build -t $(IMAGE):$(TAG) . --update-metadata
+	sudo TMPDIR=$$TMPDIR ig image build -t $(IMAGE):$(TAG) . --update-metadata --builder-image $(BUILDER_IMAGE)
 
 run:
 	sudo ig run $(IMAGE):$(TAG) --verify-image=false -o jsonpretty

--- a/pkg/ebpf/gadgets/trace_open/filesystem_patched.h
+++ b/pkg/ebpf/gadgets/trace_open/filesystem_patched.h
@@ -1,0 +1,275 @@
+// Based on
+// https://github.com/aquasecurity/tracee/blob/bd80c1d9e69e275f06810f2a0f99414aced14fa8/pkg/ebpf/c/common/filesystem.h
+
+#ifndef __COMMON_FILESYSTEM_H__
+#define __COMMON_FILESYSTEM_H__
+
+// clang-format off
+#define MAX_PERCPU_BUFSIZE  (1 << 15)  // set by the kernel as an upper bound
+#define GADGET_PATH_MAX     512        // smaller than PATH_MAX to reduce memory consumption
+#define PATH_MAX            4096
+#define MAX_STR_FILTER_SIZE 16        // bounded to size of the compared values (comm)
+#define MAX_BIN_PATH_SIZE   256       // max binary path size
+#define FILE_MAGIC_HDR_SIZE 32        // magic_write: bytes to save from a file's header
+#define FILE_MAGIC_MASK     31        // magic_write: mask used for verifier boundaries
+#define NET_SEQ_OPS_SIZE    4         // print_net_seq_ops: struct size - TODO: replace with uprobe argument
+#define NET_SEQ_OPS_TYPES   6         // print_net_seq_ops: argument size - TODO: replace with uprobe argument
+#define MAX_KSYM_NAME_SIZE  64
+#define UPROBE_MAGIC_NUMBER 20220829
+#define ARGS_BUF_SIZE       32000
+#define SEND_META_SIZE      24
+#define MAX_MEM_DUMP_SIZE   127
+
+#define MAX_PATH_COMPONENTS   80
+
+// memory related
+enum buf_idx_e
+{
+	STRING_BUF_IDX,
+	//FILE_BUF_IDX,
+	MAX_BUFFERS
+};
+
+typedef struct simple_buf {
+	u8 buf[MAX_PERCPU_BUFSIZE];
+} buf_t;
+
+#define BPF_MAP(_name, _type, _key_type, _value_type, _max_entries)                                \
+	struct {                                                                                       \
+		__uint(type, _type);                                                                       \
+		__uint(max_entries, _max_entries);                                                         \
+		__type(key, _key_type);                                                                    \
+		__type(value, _value_type);                                                                \
+	} _name SEC(".maps");
+
+
+#define BPF_PERCPU_ARRAY(_name, _value_type, _max_entries)                                         \
+	BPF_MAP(_name, BPF_MAP_TYPE_PERCPU_ARRAY, u32, _value_type, _max_entries)
+
+BPF_PERCPU_ARRAY(bufs, buf_t, MAX_BUFFERS);                        // percpu global buffer variables
+
+// undef as we don't want to use this in our gadgets. yet?
+#undef BPF_MAP
+#undef BPF_PERCPU_ARRAY
+
+static __always_inline buf_t *get_buf(int idx)
+{
+	return bpf_map_lookup_elem(&bufs, &idx);
+}
+
+static __always_inline struct dentry *get_mnt_root_ptr_from_vfsmnt(struct vfsmount *vfsmnt)
+{
+	return BPF_CORE_READ(vfsmnt, mnt_root);
+}
+
+static __always_inline struct dentry *get_d_parent_ptr_from_dentry(struct dentry *dentry)
+{
+	return BPF_CORE_READ(dentry, d_parent);
+}
+
+static inline struct mount *real_mount(struct vfsmount *mnt)
+{
+	return container_of(mnt, struct mount, mnt);
+}
+
+static __always_inline struct qstr get_d_name_from_dentry(struct dentry *dentry)
+{
+	return BPF_CORE_READ(dentry, d_name);
+}
+
+static __always_inline void *get_path_str(struct path *path)
+{
+	struct path f_path;
+	bpf_probe_read(&f_path, sizeof(struct path), path);
+	char slash = '/';
+	int zero = 0;
+	struct dentry *dentry = f_path.dentry;
+	struct vfsmount *vfsmnt = f_path.mnt;
+	struct mount *mnt_parent_p;
+
+	struct mount *mnt_p = real_mount(vfsmnt);
+	bpf_probe_read(&mnt_parent_p, sizeof(struct mount *), &mnt_p->mnt_parent);
+
+	u32 buf_off = (MAX_PERCPU_BUFSIZE >> 1);
+	struct dentry *mnt_root;
+	struct dentry *d_parent;
+	struct qstr d_name;
+	unsigned int len;
+	unsigned int off;
+	int sz;
+
+	// Get per-cpu string buffer
+	buf_t *string_p = get_buf(STRING_BUF_IDX);
+	if (string_p == NULL)
+		return NULL;
+
+#pragma unroll
+	for (int i = 0; i < MAX_PATH_COMPONENTS; i++) {
+		mnt_root = get_mnt_root_ptr_from_vfsmnt(vfsmnt);
+		d_parent = get_d_parent_ptr_from_dentry(dentry);
+		if (dentry == mnt_root || dentry == d_parent) {
+			if (dentry != mnt_root) {
+				// We reached root, but not mount root - escaped?
+				break;
+			}
+			if (mnt_p != mnt_parent_p) {
+				// We reached root, but not global root - continue with mount point path
+				bpf_probe_read(&dentry, sizeof(struct dentry *), &mnt_p->mnt_mountpoint);
+				bpf_probe_read(&mnt_p, sizeof(struct mount *), &mnt_p->mnt_parent);
+				bpf_probe_read(&mnt_parent_p, sizeof(struct mount *), &mnt_p->mnt_parent);
+				vfsmnt = &mnt_p->mnt;
+				continue;
+			}
+			// Global root - path fully parsed
+			break;
+		}
+		// Add this dentry name to path
+		d_name = get_d_name_from_dentry(dentry);
+		len = (d_name.len + 1) & (PATH_MAX - 1);
+		off = buf_off - len;
+
+		// Is string buffer big enough for dentry name?
+		sz = 0;
+		if (off <= buf_off) { // verify no wrap occurred
+			len = len & ((MAX_PERCPU_BUFSIZE >> 1) - 1);
+			sz = bpf_probe_read_str(
+				&(string_p->buf[off & ((MAX_PERCPU_BUFSIZE >> 1) - 1)]), len, (void *) d_name.name);
+		} else
+			break;
+		if (sz > 1) {
+			buf_off -= 1; // remove null byte termination with slash sign
+			bpf_probe_read(&(string_p->buf[buf_off & (MAX_PERCPU_BUFSIZE - 1)]), 1, &slash);
+			buf_off -= sz - 1;
+		} else {
+			// If sz is 0 or 1 we have an error (path can't be null nor an empty string)
+			break;
+		}
+		dentry = d_parent;
+	}
+
+	if (buf_off == (MAX_PERCPU_BUFSIZE >> 1)) {
+		// memfd files have no path in the filesystem -> extract their name.
+		// If that read fails or yields an empty string, return NULL rather
+		// than a pointer into the NEVER-CLEARED per-CPU scratch buffer:
+		// falling through here is what leaked fragments of previous events
+		// (including other containers' paths) into fpath.
+		buf_off = 0;
+		d_name = get_d_name_from_dentry(dentry);
+		sz = bpf_probe_read_str(&(string_p->buf[0]), PATH_MAX, (void *) d_name.name);
+		if (sz <= 1)
+			return NULL;
+	} else {
+		// Add leading slash
+		buf_off -= 1;
+		bpf_probe_read(&(string_p->buf[buf_off & (MAX_PERCPU_BUFSIZE - 1)]), 1, &slash);
+		// Null terminate the path string
+		bpf_probe_read(&(string_p->buf[(MAX_PERCPU_BUFSIZE >> 1) - 1]), 1, &zero);
+	}
+
+	return &string_p->buf[buf_off];
+}
+
+// Function to extract file structure from a user space file descriptor
+static __always_inline struct file * get_struct_file_for_fd(int fd_num)
+{
+	if (fd_num < 0) {
+		return NULL;
+	}
+
+	struct task_struct *task = (struct task_struct *) bpf_get_current_task();
+	if (task == NULL) {
+		return NULL;
+	}
+
+	// extract the file vector from the task_struct
+	struct file **fd = BPF_CORE_READ(task, files, fdt, fd);
+
+	// extract the file pointer from the file vector
+	struct file *f = NULL;
+	uint max_fds = BPF_CORE_READ(task, files, fdt, max_fds);
+	if (fd_num < max_fds) {
+		bpf_core_read((void *) &f, sizeof(f), &fd[fd_num]);
+	}
+
+	return f;
+}
+
+static __always_inline long read_full_path_of_open_file_fd(int fd_num, char *buf, u64 buf_len)
+{
+	struct file *file = get_struct_file_for_fd(fd_num);
+	if (file == NULL) {
+		return -1;
+	}
+
+	struct path f_path = BPF_CORE_READ(file, f_path);
+
+	// Extract the full path string
+	char* c_path = get_path_str(&f_path);
+	if (!c_path) {
+		return -1;
+	}
+	return bpf_probe_read_kernel_str(buf, buf_len, c_path);
+}
+
+
+#ifndef AT_FDCWD
+#define AT_FDCWD -100
+#endif
+
+// read_full_path_of_dfd_rel resolves a RELATIVE open path against its base --
+// the process cwd for AT_FDCWD, otherwise the directory the dirfd refers to --
+// and writes "<base>/<fname>" into buf. Unlike read_full_path_of_open_file_fd
+// this needs no file descriptor from the open itself, so it also works for
+// FAILED opens (speculative opens of not-yet-existing files, e.g. postgres
+// relation forks), which is exactly the case where fpath used to stay empty
+// and userspace fell back to the raw relative fname.
+static __always_inline long read_full_path_of_dfd_rel(int dfd, const char *user_fname,
+						      char *buf, u64 buf_len)
+{
+	struct path base;
+
+	if (dfd == AT_FDCWD) {
+		struct task_struct *task = (struct task_struct *) bpf_get_current_task();
+		if (!task)
+			return -1;
+		struct fs_struct *fs = BPF_CORE_READ(task, fs);
+		if (!fs)
+			return -1;
+		bpf_probe_read_kernel(&base, sizeof(base), &fs->pwd);
+	} else {
+		struct file *f = get_struct_file_for_fd(dfd);
+		if (!f)
+			return -1;
+		base = BPF_CORE_READ(f, f_path);
+	}
+
+	char *bstr = get_path_str(&base);
+	if (!bstr)
+		return -1;
+
+	long n = bpf_probe_read_kernel_str(buf, GADGET_PATH_MAX, bstr);
+	if (n <= 1)
+		return -1;
+
+	// n includes the terminating NUL. The base occupies buf[0 .. off-1] with a
+	// NUL at buf[off]; append "/<fname>" starting at off. The verifier needs a
+	// COMPILE-TIME bound on the destination of the second read, so cap the base
+	// prefix at a constant and always pass a constant length -- a variable
+	// remaining-length read past a variable offset is what the verifier
+	// rejects (write outside GADGET_PATH_MAX).
+	u32 off = (u32) (n - 1);
+	// Reserve a fixed tail for the appended name.
+#define REL_NAME_MAX 256
+	if (off > GADGET_PATH_MAX - REL_NAME_MAX)
+		off = GADGET_PATH_MAX - REL_NAME_MAX; // truncate base, never overflow
+	buf[off & (GADGET_PATH_MAX - 1)] = '/';
+	long m = bpf_probe_read_user_str(&buf[(off + 1) & (GADGET_PATH_MAX - 1)],
+					 REL_NAME_MAX - 1, user_fname);
+	if (m <= 1) {
+		buf[off & (GADGET_PATH_MAX - 1)] = '\0'; // undo the slash on failure
+		return -1;
+	}
+	return off + m;
+}
+
+#endif

--- a/pkg/ebpf/gadgets/trace_open/filesystem_patched.h
+++ b/pkg/ebpf/gadgets/trace_open/filesystem_patched.h
@@ -148,11 +148,6 @@ static __always_inline void *get_path_str(struct path *path)
 	}
 
 	if (buf_off == (MAX_PERCPU_BUFSIZE >> 1)) {
-		// memfd files have no path in the filesystem -> extract their name.
-		// If that read fails or yields an empty string, return NULL rather
-		// than a pointer into the NEVER-CLEARED per-CPU scratch buffer:
-		// falling through here is what leaked fragments of previous events
-		// (including other containers' paths) into fpath.
 		buf_off = 0;
 		d_name = get_d_name_from_dentry(dentry);
 		sz = bpf_probe_read_str(&(string_p->buf[0]), PATH_MAX, (void *) d_name.name);
@@ -216,15 +211,10 @@ static __always_inline long read_full_path_of_open_file_fd(int fd_num, char *buf
 #define AT_FDCWD -100
 #endif
 
-// read_full_path_of_dfd_rel resolves a RELATIVE open path against its base --
-// the process cwd for AT_FDCWD, otherwise the directory the dirfd refers to --
-// and writes "<base>/<fname>" into buf. Unlike read_full_path_of_open_file_fd
-// this needs no file descriptor from the open itself, so it also works for
-// FAILED opens (speculative opens of not-yet-existing files, e.g. postgres
-// relation forks), which is exactly the case where fpath used to stay empty
-// and userspace fell back to the raw relative fname.
+// buf is always GADGET_PATH_MAX bytes: the verifier needs a compile-time bound
+// for the masked writes below, so the size is not a runtime parameter.
 static __always_inline long read_full_path_of_dfd_rel(int dfd, const char *user_fname,
-						      char *buf, u64 buf_len)
+						      char *buf)
 {
 	struct path base;
 
@@ -232,10 +222,7 @@ static __always_inline long read_full_path_of_dfd_rel(int dfd, const char *user_
 		struct task_struct *task = (struct task_struct *) bpf_get_current_task();
 		if (!task)
 			return -1;
-		struct fs_struct *fs = BPF_CORE_READ(task, fs);
-		if (!fs)
-			return -1;
-		bpf_probe_read_kernel(&base, sizeof(base), &fs->pwd);
+		base = BPF_CORE_READ(task, fs, pwd);
 	} else {
 		struct file *f = get_struct_file_for_fd(dfd);
 		if (!f)
@@ -251,22 +238,20 @@ static __always_inline long read_full_path_of_dfd_rel(int dfd, const char *user_
 	if (n <= 1)
 		return -1;
 
-	// n includes the terminating NUL. The base occupies buf[0 .. off-1] with a
-	// NUL at buf[off]; append "/<fname>" starting at off. The verifier needs a
-	// COMPILE-TIME bound on the destination of the second read, so cap the base
-	// prefix at a constant and always pass a constant length -- a variable
-	// remaining-length read past a variable offset is what the verifier
-	// rejects (write outside GADGET_PATH_MAX).
 	u32 off = (u32) (n - 1);
-	// Reserve a fixed tail for the appended name.
 #define REL_NAME_MAX 256
-	if (off > GADGET_PATH_MAX - REL_NAME_MAX)
-		off = GADGET_PATH_MAX - REL_NAME_MAX; // truncate base, never overflow
+	// Base too long to append the name within GADGET_PATH_MAX: fail closed
+	// rather than truncate the base into a plausible but wrong absolute path.
+	if (off >= GADGET_PATH_MAX - REL_NAME_MAX)
+		return -1;
+	// Redundant given the check above, but the verifier needs the constant
+	// mask to prove the REL_NAME_MAX write below stays in bounds.
+	off &= (GADGET_PATH_MAX - REL_NAME_MAX - 1);
 	buf[off & (GADGET_PATH_MAX - 1)] = '/';
 	long m = bpf_probe_read_user_str(&buf[(off + 1) & (GADGET_PATH_MAX - 1)],
 					 REL_NAME_MAX - 1, user_fname);
 	if (m <= 1) {
-		buf[off & (GADGET_PATH_MAX - 1)] = '\0'; // undo the slash on failure
+		buf[off & (GADGET_PATH_MAX - 1)] = '\0';
 		return -1;
 	}
 	return off + m;

--- a/pkg/ebpf/gadgets/trace_open/gadget.yaml
+++ b/pkg/ebpf/gadgets/trace_open/gadget.yaml
@@ -1,0 +1,91 @@
+name: trace open
+description: trace open files
+homepageURL: https://inspektor-gadget.io/
+documentationURL: https://www.inspektor-gadget.io/docs/latest/gadgets/trace_open
+sourceURL: https://github.com/inspektor-gadget/inspektor-gadget/tree/main/gadgets/trace_open
+datasources:
+  open:
+    fields:
+      error_raw:
+        annotations:
+          columns.hidden: "true"
+      fd:
+        annotations:
+          columns.alignment: right
+          columns.maxwidth: "3"
+          columns.minwidth: "2"
+          description: File descriptor. 0 in case of error
+      flags:
+        annotations:
+          columns.hidden: "true"
+          columns.width: "10"
+      flags_raw:
+        annotations:
+          columns.hidden: "true"
+      fname:
+        annotations:
+          columns.minwidth: "24"
+          columns.width: "32"
+          description: File name as given in the open syscall
+      fpath:
+        annotations:
+          columns.minwidth: "24"
+          columns.width: "32"
+          description: Full file path after symlink resolution (require --paths flag)
+      mode:
+        annotations:
+          description: File access mode
+      mode_raw:
+        annotations:
+          columns.hidden: "true"
+      proc:
+        annotations:
+          description: 'TODO: Fill field description'
+      timestamp_raw:
+        annotations:
+          description: 'TODO: Fill field description'
+      ustack:
+        annotations:
+          description: 'TODO: Fill field description'
+params:
+  ebpf:
+    collect_build_id:
+      key: collect_build_id
+      defaultValue: ""
+      description: 'TODO: Fill parameter description'
+    collect_ustack:
+      key: collect_ustack
+      defaultValue: ""
+      description: 'TODO: Fill parameter description'
+    ig_build_id_max_entries:
+      key: ig_build_id_max_entries
+      defaultValue: ""
+      description: 'TODO: Fill parameter description'
+    paths:
+      key: paths
+      defaultValue: "false"
+      description: Show file path after symlink resolution
+    targ_comm:
+      key: targ_comm
+      defaultValue: ""
+      description: 'TODO: Fill parameter description'
+    targ_failed:
+      key: failed
+      defaultValue: "false"
+      description: Show only failed events
+    targ_gid:
+      key: targ_gid
+      defaultValue: ""
+      description: 'TODO: Fill parameter description'
+    targ_pid:
+      key: targ_pid
+      defaultValue: ""
+      description: 'TODO: Fill parameter description'
+    targ_tid:
+      key: targ_tid
+      defaultValue: ""
+      description: 'TODO: Fill parameter description'
+    targ_uid:
+      key: targ_uid
+      defaultValue: ""
+      description: 'TODO: Fill parameter description'

--- a/pkg/ebpf/gadgets/trace_open/program.bpf.c
+++ b/pkg/ebpf/gadgets/trace_open/program.bpf.c
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2019 Facebook
+// Copyright (c) 2020 Netflix
+
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+
+#include <gadget/buffer.h>
+#include <gadget/common.h>
+#include <gadget/filter.h>
+#include <gadget/macros.h>
+#include <gadget/types.h>
+#include <gadget/user_stack_map.h>
+#include "filesystem_patched.h"
+
+#define TASK_RUNNING 0
+#define NAME_MAX 255
+
+struct args_t {
+	const char *fname;
+	int flags;
+	__u16 mode;
+	// dfd of openat (AT_FDCWD for plain open): needed to resolve a relative
+	// fname against its base, including for FAILED opens where no file
+	// descriptor exists to walk.
+	int dfd;
+};
+
+struct event {
+	gadget_timestamp timestamp_raw;
+	struct gadget_process proc;
+
+	gadget_errno error_raw;
+	__u32 fd;
+	gadget_file_flags flags_raw;
+	gadget_file_mode mode_raw;
+	struct gadget_user_stack ustack;
+	char fname[NAME_MAX];
+	char fpath[GADGET_PATH_MAX];
+};
+
+const volatile bool targ_failed = false;
+const volatile bool paths = false;
+
+GADGET_PARAM(targ_failed);
+GADGET_PARAM(paths);
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 10240);
+	__type(key, u32);
+	__type(value, struct args_t);
+} start SEC(".maps");
+
+GADGET_TRACER_MAP(events, 1024 * 256);
+
+GADGET_TRACER(open, events, event);
+
+static __always_inline int trace_enter(int dfd, const char *filename, int flags,
+				       __u16 mode)
+{
+	__u64 pid = bpf_get_current_pid_tgid();
+
+	if (gadget_should_discard_data_current())
+		return 0;
+
+	struct args_t args = {};
+	args.fname = filename;
+	args.flags = flags;
+	args.mode = mode;
+	args.dfd = dfd;
+	bpf_map_update_elem(&start, &pid, &args, 0);
+
+	return 0;
+}
+
+#ifndef __TARGET_ARCH_arm64
+SEC("tracepoint/syscalls/sys_enter_open")
+int ig_open_e(struct syscall_trace_enter *ctx)
+{
+	return trace_enter(AT_FDCWD, (const char *)ctx->args[0],
+			   (int)ctx->args[1], (__u16)ctx->args[2]);
+}
+#endif /* !__TARGET_ARCH_arm64 */
+
+SEC("tracepoint/syscalls/sys_enter_openat")
+int ig_openat_e(struct syscall_trace_enter *ctx)
+{
+	return trace_enter((int)ctx->args[0], (const char *)ctx->args[1],
+			   (int)ctx->args[2], (__u16)ctx->args[3]);
+}
+
+static __always_inline int trace_exit(struct syscall_trace_exit *ctx)
+{
+	struct event *event;
+	struct args_t *ap;
+	long int ret;
+	__u32 fd;
+	__s32 errval;
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+
+	// pid from kernel po
+	u32 pid = (u32)pid_tgid;
+
+	ap = bpf_map_lookup_elem(&start, &pid);
+	if (!ap)
+		return 0; /* missed entry */
+	ret = ctx->ret;
+	if (targ_failed && ret >= 0)
+		goto cleanup; /* want failed only */
+
+	event = gadget_reserve_buf(&events, sizeof(*event));
+	if (!event)
+		goto cleanup;
+
+	fd = 0;
+	errval = 0;
+	if (ret >= 0) {
+		fd = ret;
+
+		if (paths) {
+			long r = read_full_path_of_open_file_fd(
+				fd, (char *)event->fpath, sizeof(event->fpath));
+			if (r <= 0)
+				event->fpath[0] = '\0';
+		}
+	} else {
+		errval = -ret;
+		// gadget_reserve_buf does not zero the reservation: without this,
+		// fpath on a failed open carries whatever the ring slot last held.
+		if (paths)
+			event->fpath[0] = '\0';
+	}
+
+	// A relative fname with no resolved fpath: join it against its base
+	// (cwd for AT_FDCWD, else the dirfd's path). Works for failed opens
+	// too, which have no fd to walk -- previously those were reported as
+	// the raw relative name and userspace fabricated "/<relative>".
+	if (paths && event->fpath[0] == '\0') {
+		char first = 0;
+		bpf_probe_read_user(&first, 1, ap->fname);
+		if (first != 0 && first != '/') {
+			long r = read_full_path_of_dfd_rel(
+				ap->dfd, ap->fname, (char *)event->fpath,
+				sizeof(event->fpath));
+			if (r <= 0)
+				event->fpath[0] = '\0';
+		}
+	}
+
+	/* event data */
+	gadget_process_populate(&event->proc);
+	gadget_get_user_stack(ctx, &event->ustack);
+
+	bpf_probe_read_user_str(&event->fname, sizeof(event->fname), ap->fname);
+	event->flags_raw = ap->flags;
+	event->mode_raw = ap->mode;
+	event->error_raw = errval;
+	event->fd = fd;
+	event->timestamp_raw = bpf_ktime_get_boot_ns();
+
+	/* emit event */
+	gadget_submit_buf(ctx, &events, event, sizeof(*event));
+
+cleanup:
+	bpf_map_delete_elem(&start, &pid);
+	return 0;
+}
+
+#ifndef __TARGET_ARCH_arm64
+SEC("tracepoint/syscalls/sys_exit_open")
+int ig_open_x(struct syscall_trace_exit *ctx)
+{
+	return trace_exit(ctx);
+}
+#endif /* !__TARGET_ARCH_arm64 */
+
+SEC("tracepoint/syscalls/sys_exit_openat")
+int ig_openat_x(struct syscall_trace_exit *ctx)
+{
+	return trace_exit(ctx);
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/pkg/ebpf/gadgets/trace_open/program.bpf.c
+++ b/pkg/ebpf/gadgets/trace_open/program.bpf.c
@@ -21,9 +21,6 @@ struct args_t {
 	const char *fname;
 	int flags;
 	__u16 mode;
-	// dfd of openat (AT_FDCWD for plain open): needed to resolve a relative
-	// fname against its base, including for FAILED opens where no file
-	// descriptor exists to walk.
 	int dfd;
 };
 
@@ -116,6 +113,7 @@ static __always_inline int trace_exit(struct syscall_trace_exit *ctx)
 
 	fd = 0;
 	errval = 0;
+	event->fpath[0] = '\0';
 	if (ret >= 0) {
 		fd = ret;
 
@@ -127,23 +125,14 @@ static __always_inline int trace_exit(struct syscall_trace_exit *ctx)
 		}
 	} else {
 		errval = -ret;
-		// gadget_reserve_buf does not zero the reservation: without this,
-		// fpath on a failed open carries whatever the ring slot last held.
-		if (paths)
-			event->fpath[0] = '\0';
 	}
 
-	// A relative fname with no resolved fpath: join it against its base
-	// (cwd for AT_FDCWD, else the dirfd's path). Works for failed opens
-	// too, which have no fd to walk -- previously those were reported as
-	// the raw relative name and userspace fabricated "/<relative>".
 	if (paths && event->fpath[0] == '\0') {
 		char first = 0;
 		bpf_probe_read_user(&first, 1, ap->fname);
 		if (first != 0 && first != '/') {
 			long r = read_full_path_of_dfd_rel(
-				ap->dfd, ap->fname, (char *)event->fpath,
-				sizeof(event->fpath));
+				ap->dfd, ap->fname, (char *)event->fpath);
 			if (r <= 0)
 				event->fpath[0] = '\0';
 		}

--- a/tests/component_test.go
+++ b/tests/component_test.go
@@ -3392,3 +3392,80 @@ func Test_36_MultiContainerPerContainerBinding(t *testing.T) {
 	assert.Equal(t, 0, countR0001("sidecar", "whoami"),
 		"whoami IS in mc35-sidecar — must NOT fire R0001 in sidecar (non-zero => app's CP leaked in)")
 }
+
+// Test_43_RelativeOpenPathResolution pins the gadget behaviour that a relative
+// open (chdir + openat against a relative name) is recorded in the learned
+// ContainerProfile as its RESOLVED absolute path, not a fabricated root.
+//
+// This is the regression that produced /base/<oid>/<relfile>, /pg_wal/<seg>
+// and /backup_label in the postgres profiles: the gadget only resolved a full
+// path from the fd a successful open returned, so a relative open (and every
+// failed speculative open, which has no fd at all) fell back to the raw
+// relative name, which NormalizePath then turned into a bogus root by
+// prefixing "/". The workload chdir's into /data and opens reldir/present.txt
+// (exists) and reldir/absent.txt (never exists, the failed-open case).
+//
+// Correct: both are learned as /data/reldir/<name>.
+// Regressed: they appear as the fabricated root /reldir/<name>, and the true
+// /data/reldir/... entry is absent.
+func Test_43_RelativeOpenPathResolution(t *testing.T) {
+	start := time.Now()
+	defer tearDownTest(t, start)
+
+	ns := testutils.NewRandomNamespace()
+	wl, err := testutils.NewTestWorkload(ns.Name,
+		path.Join(utils.CurrentDir(), "resources/relative-open-deployment.yaml"))
+	require.NoError(t, err, "create relative-open workload in ns %s", ns.Name)
+	require.NoError(t, wl.WaitForReady(80), "relative-open workload not ready in ns %s", ns.Name)
+
+	// Let the profile learn the chdir'd relative opens, then reach 'completed'.
+	require.NoError(t, wl.WaitForContainerProfileCompletion(60),
+		"ContainerProfile did not complete for the relative-open workload")
+
+	cp, err := wl.GetContainerProfile("relative-open")
+	require.NoError(t, err, "get learned ContainerProfile")
+
+	opens := make([]string, 0, len(cp.Spec.Opens))
+	for _, o := range cp.Spec.Opens {
+		opens = append(opens, o.Path)
+	}
+	t.Logf("learned opens (%d): %v", len(opens), opens)
+
+	// matchesResolved reports whether some open is the fully-resolved path for
+	// name -- /data/reldir/<name> possibly ending in a dynamic wildcard segment
+	// (the detector may collapse the leaf to ...).
+	matchesResolved := func(name string) bool {
+		for _, p := range opens {
+			if p == "/data/reldir/"+name {
+				return true
+			}
+			// tolerate a collapsed leaf: /data/reldir/...
+			if strings.HasPrefix(p, "/data/reldir/") {
+				return true
+			}
+		}
+		return false
+	}
+
+	// isFabricatedRoot reports whether some open is the bogus root form for
+	// name -- a first segment of "reldir" (i.e. /reldir/<name>), or the raw
+	// name promoted to a root (/<name>). Either means the relative open was not
+	// resolved against its cwd.
+	fabricated := make([]string, 0)
+	for _, p := range opens {
+		segs := strings.Split(strings.TrimPrefix(p, "/"), "/")
+		if len(segs) == 0 {
+			continue
+		}
+		if segs[0] == "reldir" || p == "/present.txt" || p == "/absent.txt" {
+			fabricated = append(fabricated, p)
+		}
+	}
+
+	assert.Empty(t, fabricated,
+		"relative opens must not be recorded as fabricated roots (unresolved cwd) -- got %v", fabricated)
+	assert.True(t, matchesResolved("present.txt"),
+		"the existing relative open reldir/present.txt must be learned as /data/reldir/present.txt; opens=%v", opens)
+	assert.True(t, matchesResolved("absent.txt"),
+		"the FAILED relative open reldir/absent.txt (no fd) must also resolve to /data/reldir/absent.txt; opens=%v", opens)
+}

--- a/tests/component_test.go
+++ b/tests/component_test.go
@@ -3431,16 +3431,13 @@ func Test_43_RelativeOpenPathResolution(t *testing.T) {
 	}
 	t.Logf("learned opens (%d): %v", len(opens), opens)
 
-	// matchesResolved reports whether some open is the fully-resolved path for
-	// name -- /data/reldir/<name> possibly ending in a dynamic wildcard segment
-	// (the detector may collapse the leaf to ...).
+	// matchesResolved reports whether the exact fully-resolved path for name
+	// (/data/reldir/<name>) was learned. Exact match only: a "/data/reldir/"
+	// prefix tolerance would let present.txt's open satisfy absent.txt and hide
+	// a failed-open resolution regression -- the very thing this test guards.
 	matchesResolved := func(name string) bool {
 		for _, p := range opens {
 			if p == "/data/reldir/"+name {
-				return true
-			}
-			// tolerate a collapsed leaf: /data/reldir/...
-			if strings.HasPrefix(p, "/data/reldir/") {
 				return true
 			}
 		}

--- a/tests/resources/relative-open-deployment.yaml
+++ b/tests/resources/relative-open-deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: relative-open
+  name: relative-open-deployment
+spec:
+  selector:
+    matchLabels:
+      app: relative-open
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: relative-open
+    spec:
+      containers:
+      - name: relative-open
+        image: python:3.12-slim
+        # Reproduce the postgres access pattern the gadget must resolve:
+        # chdir into a data dir, then open files by a RELATIVE path -- both an
+        # existing file and a not-yet-existing one (the speculative/failed open
+        # that has no fd for the resolver to walk). Before the dirfd/cwd fix
+        # these were recorded as fabricated roots (/reldir/present.txt); after,
+        # as the resolved absolute path (/data/reldir/present.txt). python's
+        # open() issues openat(AT_FDCWD, "reldir/<name>", ...), the exact
+        # relative form; the failed open of absent.txt exercises the no-fd path.
+        command: ["python3", "-u", "-c"]
+        args:
+          - |
+            import os, time
+            os.makedirs('/data/reldir', exist_ok=True)
+            with open('/data/reldir/present.txt', 'w') as f:
+                f.write('hello')
+            os.chdir('/data')
+            while True:
+                try:
+                    open('reldir/present.txt').close()
+                except OSError:
+                    pass
+                try:
+                    open('reldir/absent.txt').close()
+                except OSError:
+                    pass
+                time.sleep(2)
+        volumeMounts:
+          - name: data
+            mountPath: /data
+      volumes:
+        - name: data
+          emptyDir: {}


### PR DESCRIPTION
## Side-by-side: the same postgres deploy, three node-agents

One identical recipe per leg on a fresh 2-node k3s (kernel 6.1.167): `example/postgres/distros/deploy-distros.sh oss` into a clean namespace, one 50k-row `INSERT` + `CHECKPOINT`, learn to completion, read the learned ContainerProfile.

| leg | node-agent | learned opens | **fabricated roots** | data-dir paths |
|---|---|---|---|---|
| **A — upstream stock** (chart 1.40.3, quay) | `v0.3.158` lineage | 253 | **26** | `/base/16384/16423_fsm`, `/backup_label`, `/base/1/⋯` … |
| **B — fork current** (`v0.3.190`, stock gadget) | ghcr `v0.3.190` | 227 | **22** | same shapes |
| **C — fork + this PR's gadget** | same `v0.3.190` binary, fixed `tracers.tar` | 221 | **0** | `/var/lib/postgresql/data/pgdata/base/16384/⋯`, `…/pgdata/backup_label` |

The same file, three ways:

```
A/B:  /base/16384/16423_fsm            <- fabricated root (relative name + "/" prefix)
C:    /var/lib/postgresql/data/pgdata/base/16384/⋯    <- resolved against the dirfd/cwd
A/B:  /backup_label
C:    /var/lib/postgresql/data/pgdata/backup_label
```

Leg B vs A also shows what the fork's `IsResolvedFullPath` guard (#60) already fixed — the *scrambled-fragment* class (`/ocal.sh`, wildcard-root collapse) that upstream still has over longer windows; the fabricated-relative class is untouched by that guard and only this PR removes it.

CI: `Test_43_RelativeOpenPathResolution` (added here) learns a chdir'd relative-open workload in kind and asserts no fabricated roots and that even the FAILED open resolves — passing:

```
learned opens (34): [/data/reldir/absent.txt /data/reldir/present.txt /proc/⋯/task/1/fd ...]
--- PASS: Test_43_RelativeOpenPathResolution (185.66s)
```

Full command transcript of the three-leg demo is in the PR comments.

---
Off `mirrormain`. Fixes the postgres data-dir fabrication left open in #64 / kubescape#874 — the half `IsResolvedFullPath` (#60) could not reach.

## Problem

`trace_open` only resolves a full path from the fd a **successful** open returns. Two failure modes fed garbage into learned ContainerProfiles:

1. **Relative opens, no fd.** A failed open has no descriptor, so `fpath` stays empty and userspace falls back to the raw `fname`. Postgres `chdir`s into PGDATA and opens relative (`base/<oid>/<relfile>`, `pg_wal/<seg>`, `backup_label`), and speculatively probes `_fsm`/`_vm`/`_init` forks that don't exist yet. `NormalizePath` prefixes `/` → `/base/…`, `/pg_wal/…`, `/backup_label`, `/.pgpass`. **72 fabricated entries** across the three postgres server profiles.
2. **Stale scratch buffer.** `get_path_str()` fell through to a pointer into the never-cleared per-CPU buffer on an empty walk, so `fpath` could carry a fragment of an unrelated event — including another container's path.

The descriptor is the wrong key: the base of a relative open is its **dirfd** (or cwd for `AT_FDCWD`), which exists whether or not the open succeeds.

## Fix

`trace_open` vendored from IG v0.48.1 and patched:

- carry `dfd` through `args_t` (`AT_FDCWD` for `open`, `ctx->args[0]` for `openat`);
- in the exit probe, when `fpath` is empty and `fname` is relative, resolve the base with the existing `get_path_str()` (`task->fs->pwd` for `AT_FDCWD`, else the dirfd's `file->f_path`) and join `<base>/<fname>` — **runs regardless of `ret`**, so failed opens resolve;
- clear `fpath` on the failed-open branch (the ring slot isn't zeroed);
- `get_path_str()` returns `NULL` on an empty walk instead of the stale buffer.

The join uses a compile-time-bounded read into a constant-offset window (`REL_NAME_MAX`) — a variable-length read at a variable offset is what the verifier rejects. Base truncates rather than overflows; base+name over `GADGET_PATH_MAX` fails closed to empty (a wrong absolute path is worse than none).

Built under the name node-agent already pins (`…/trace_open:v0.48.1`), so `open.go` is unchanged; the Makefile builds it from source instead of pulling.

## Verified — 2-node k3s, kernel 6.1.167, node-agent v0.3.190, patched tracers.tar

| | stock | patched |
|---|---|---|
| fabricated data-dir roots (3 postgres servers) | **72** | **3** |
| resolved `/var/lib/postgresql/data/pgdata/…` (oss / cnpg) | ~50 | **85 / 169** |
| bare `/*` or wildcard root | none | none |

The 3 leftovers are `/` and a genuine `/.pgpass` (postgres opens it with `HOME=/`), not fabrications. Concrete pairs:

```
/base/16384/16423_fsm  ->  /var/lib/postgresql/data/pgdata/base/16384/⋯
/backup_label          ->  /var/lib/postgresql/data/pgdata/backup_label
```

redis/valkey unchanged (9 real roots, `/runc` the only single-segment entry).

**Verifier:** loads clean on both nodes (an earlier variable-length join was rejected; the bounded rewrite is what shipped).

**Benchmark:** node-agent CPU during an identical 6× insert+checkpoint+vacuum did not regress — ~43% avg stock, ~31% avg patched, wall-time unchanged. Fewer distinct fabricated paths churn the learning pipeline.

## Note

`headlessProcRegex` in `pkg/utils/path.go` re-roots `/proc/<pid>/…` — the same relative-name pattern this now resolves at source. It can likely be retired in a follow-up once this is validated in CI, but I left it in place here to keep the change scoped to the gadget.