### PR TITLE
feat(cel/network): serviceRef/serviceSelector/host neighbor resolution (stacked on #90)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -39,11 +39,13 @@ import (
 	"github.com/kubescape/node-agent/pkg/malwaremanager"
 	malwaremanagerv1 "github.com/kubescape/node-agent/pkg/malwaremanager/v1"
 	otelmetrics "github.com/kubescape/node-agent/pkg/metricsmanager/otel"
+	"github.com/kubescape/node-agent/pkg/networkpeer"
 	"github.com/kubescape/node-agent/pkg/networkstream"
 	networkstreamv1 "github.com/kubescape/node-agent/pkg/networkstream/v1"
 	"github.com/kubescape/node-agent/pkg/nodeprofilemanager"
 	nodeprofilemanagerv1 "github.com/kubescape/node-agent/pkg/nodeprofilemanager/v1"
 	"github.com/kubescape/node-agent/pkg/objectcache"
+
 	"github.com/kubescape/node-agent/pkg/objectcache/containerprofilecache"
 	"github.com/kubescape/node-agent/pkg/objectcache/dnscache"
 	"github.com/kubescape/node-agent/pkg/objectcache/k8scache"
@@ -72,6 +74,7 @@ import (
 	"github.com/kubescape/node-agent/pkg/watcher/seccompprofilewatcher"
 	goruntime "go.opentelemetry.io/contrib/instrumentation/runtime"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
 )
 
 func main() {
@@ -321,6 +324,29 @@ func main() {
 		ruleBindingCache.AddNotifier(&ruleBindingNotify)
 
 		cpc := containerprofilecache.NewContainerProfileCache(cfg, storageClient, k8sObjectCache, metricsProvider)
+		// Resolve serviceRef/serviceSelector/entity network neighbors against
+		// live cluster state (Service ClusterIPs + endpoints, Node IPs + CNI
+		// gateway) at projection time.
+		svcInformers := informers.NewSharedInformerFactory(k8sClient.GetKubernetesClient(), 0)
+		serviceLister := networkpeer.NewInformerLister(
+			svcInformers.Core().V1().Services().Lister(),
+			svcInformers.Discovery().V1().EndpointSlices().Lister(),
+			svcInformers.Core().V1().Nodes().Lister(),
+			cfg.NodeName,
+		)
+		svcInformers.Start(ctx.Done())
+		// Bound the initial sync so a slow/unreachable apiserver can't hang
+		// startup; the informers keep syncing in the background afterwards, so
+		// serviceRef/entity neighbors resolve as the caches fill.
+		syncCtx, cancelSync := context.WithTimeout(ctx, 30*time.Second)
+		for typ, ok := range svcInformers.WaitForCacheSync(syncCtx.Done()) {
+			if !ok {
+				logger.L().Warning("service-neighbor informer not synced at startup",
+					helpers.String("type", typ.String()))
+			}
+		}
+		cancelSync()
+		cpc.SetServiceLister(serviceLister)
 		cpc.Start(ctx)
 		if cpm, ok := containerProfileManager.(*containerprofilemanagerv1.ContainerProfileManager); ok {
 			cpm.SetCompletionNotifier(cpc)

--- a/go.mod
+++ b/go.mod
@@ -481,3 +481,5 @@ replace github.com/anchore/syft => github.com/kubescape/syft v1.32.0-ks.2
 replace github.com/anchore/stereoscope => github.com/anchore/stereoscope v0.1.9
 
 replace github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.2.1
+
+replace github.com/kubescape/storage => github.com/k8sstormcenter/storage v0.0.240-0.20260823123818-6f3a2ee6385d

--- a/go.sum
+++ b/go.sum
@@ -853,6 +853,8 @@ github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHm
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/k8sstormcenter/storage v0.0.240-0.20260823123818-6f3a2ee6385d h1:4d7cpcoXpp8ZJXV2W/ubX5WW78gn9diy9qvLFbROvV0=
+github.com/k8sstormcenter/storage v0.0.240-0.20260823123818-6f3a2ee6385d/go.mod h1:d/1hqWPda2clsjx2wmQgysnB5dThIo3rDKP7RWx+v+M=
 github.com/kastenhq/goversion v0.0.0-20230811215019-93b2f8823953 h1:WdAeg/imY2JFPc/9CST4bZ80nNJbiBFCAdSZCSgrS5Y=
 github.com/kastenhq/goversion v0.0.0-20230811215019-93b2f8823953/go.mod h1:6o+UrvuZWc4UTyBhQf0LGjW9Ld7qJxLz/OqvSOWWlEc=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
@@ -885,8 +887,6 @@ github.com/kubescape/go-logger v0.0.32 h1:4mI+XJOV8VFCMewrEE9VIFEIOhzXokYT3nFpNf
 github.com/kubescape/go-logger v0.0.32/go.mod h1:Alj7JBQ8/WCxbXe8Ura6ZheSRK45E0p21M3xeqedX90=
 github.com/kubescape/k8s-interface v0.0.214 h1:j7KP0/5VvYOoQdBGV2+gRM3qnR8PWLAGF8RM/k/DmJ0=
 github.com/kubescape/k8s-interface v0.0.214/go.mod h1:WNYUG93aZ5kDmuaRKFLtVhp18Yc6EfaHdD1gLYtVTN4=
-github.com/kubescape/storage v0.0.303 h1:0nXI6E07lbWsg7iEH04vR4kwiekj//uCQl/La+8j4aM=
-github.com/kubescape/storage v0.0.303/go.mod h1:d/1hqWPda2clsjx2wmQgysnB5dThIo3rDKP7RWx+v+M=
 github.com/kubescape/syft v1.32.0-ks.2 h1:xdUksUmKEyyVKsTfJDYW8Z5HawVJtelsUolPOsWtDx0=
 github.com/kubescape/syft v1.32.0-ks.2/go.mod h1:E6Kd4iBM2ljUOUQvSt7hVK6vBwaHkMXwcvBZmGMSY5o=
 github.com/kubescape/workerpool v0.0.0-20250526074519-0e4a4e7f44cf h1:hI0jVwrB6fT4GJWvuUjzObfci1CUknrZdRHfnRVtKM0=

--- a/pkg/networkpeer/expand.go
+++ b/pkg/networkpeer/expand.go
@@ -1,0 +1,109 @@
+package networkpeer
+
+import (
+	"strings"
+
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+)
+
+// ExpandServiceNeighbors resolves every serviceRef / serviceSelector / entity
+// neighbor in the list against the cluster view and returns equivalent
+// synthesized ipAddresses neighbors (one per source neighbor, carrying the
+// resolved IPs and the source neighbor's own ports).
+//
+// The synthesized neighbors are ordinary selector-free ipAddresses entries, so
+// the existing port-sensitive address matcher handles them with no further
+// change — a serviceRef/host neighbor becomes exactly the narrow, resolved
+// ipAddresses entry it stands for. Neighbors that resolve to nothing (unknown
+// Service, selector matching nothing, unknown entity) contribute nothing —
+// never a match-all. Callers append the result to the same direction (egress
+// or ingress) before projecting the profile.
+func ExpandServiceNeighbors(neighbors []v1beta1.NetworkNeighbor, l Lister) []v1beta1.NetworkNeighbor {
+	if l == nil {
+		return nil
+	}
+	var out []v1beta1.NetworkNeighbor
+	for i := range neighbors {
+		n := &neighbors[i]
+		spec, ok := specFromNeighbor(n)
+		if !ok {
+			continue
+		}
+		ips := ResolveIPs(spec, l)
+		if len(ips) == 0 {
+			continue
+		}
+		out = append(out, v1beta1.NetworkNeighbor{
+			Identifier:  n.Identifier + "-resolved",
+			Type:        n.Type,
+			IPAddresses: ips,
+			Ports:       n.Ports,
+		})
+	}
+	return out
+}
+
+// WithResolvedServiceNeighbors returns cp with every serviceRef/serviceSelector/
+// entity neighbor expanded into equivalent selector-free ipAddresses neighbors
+// (appended to the same direction), so the projection's existing address
+// surface enforces them. It is a no-op — returning cp unchanged — when the
+// lister is nil or nothing resolves, and it never mutates the input: a copy is
+// made only when there is something to add. Call it immediately before
+// projecting a ContainerProfile.
+func WithResolvedServiceNeighbors(cp *v1beta1.ContainerProfile, l Lister) *v1beta1.ContainerProfile {
+	if cp == nil || l == nil {
+		return cp
+	}
+	egExtra := ExpandServiceNeighbors(cp.Spec.Egress, l)
+	inExtra := ExpandServiceNeighbors(cp.Spec.Ingress, l)
+	if len(egExtra) == 0 && len(inExtra) == 0 {
+		return cp
+	}
+	out := cp.DeepCopy()
+	out.Spec.Egress = append(out.Spec.Egress, egExtra...)
+	out.Spec.Ingress = append(out.Spec.Ingress, inExtra...)
+	return out
+}
+
+// specFromNeighbor extracts a PeerSpec from a NetworkNeighbor, reporting false
+// if the neighbor declares none of the service/entity selectors (a plain
+// ipAddresses / dnsNames / podSelector neighbor is left untouched).
+func specFromNeighbor(n *v1beta1.NetworkNeighbor) (PeerSpec, bool) {
+	spec := PeerSpec{Ports: portsFromNeighbor(n.Ports)}
+	switch {
+	case n.Entity != "":
+		spec.Entity = n.Entity
+	case n.ServiceRefName != "":
+		spec.ServiceRef = &ServiceRef{Namespace: n.ServiceRefNamespace, Name: n.ServiceRefName}
+	case n.ServiceSelector != nil:
+		// Only equality (matchLabels) is honored. A MatchExpressions clause or
+		// an empty matchLabels would either be silently ignored (broadening the
+		// match) or resolve to every Service — fail closed instead.
+		if len(n.ServiceSelector.MatchExpressions) > 0 || len(n.ServiceSelector.MatchLabels) == 0 {
+			return PeerSpec{}, false
+		}
+		spec.ServiceSelector = n.ServiceSelector.MatchLabels
+		if n.NamespaceSelector != nil {
+			spec.NamespaceLabels = n.NamespaceSelector.MatchLabels
+		}
+	default:
+		return PeerSpec{}, false
+	}
+	return spec, true
+}
+
+func portsFromNeighbor(ports []v1beta1.NetworkPort) []PortProto {
+	if len(ports) == 0 {
+		return nil
+	}
+	out := make([]PortProto, 0, len(ports))
+	for i := range ports {
+		p := &ports[i]
+		var port int32
+		if p.Port != nil {
+			port = *p.Port
+		}
+		out = append(out, PortProto{Port: port, Protocol: strings.ToUpper(string(p.Protocol))})
+	}
+	return out
+}

--- a/pkg/networkpeer/expand_test.go
+++ b/pkg/networkpeer/expand_test.go
@@ -1,0 +1,154 @@
+package networkpeer
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+)
+
+func port(name string, p int32) v1beta1.NetworkPort {
+	return v1beta1.NetworkPort{Name: name, Protocol: "TCP", Port: &p}
+}
+
+// TestExpandServiceNeighbors_Egress: a serviceRef (alertmanager) + a host
+// entity neighbor expand into selector-free ipAddresses neighbors carrying the
+// resolved IPs and the original ports; a plain ipAddresses neighbor and an
+// unresolvable serviceRef contribute nothing.
+func TestExpandServiceNeighbors_Egress(t *testing.T) {
+	l := realFluxTopology()
+	in := []v1beta1.NetworkNeighbor{
+		{Identifier: "am", Type: "internal", ServiceRefNamespace: "honey", ServiceRefName: "alertmanager", Ports: []v1beta1.NetworkPort{port("TCP-9093", 9093)}},
+		{Identifier: "plain", Type: "internal", IPAddresses: []string{"10.43.0.0/16"}, Ports: []v1beta1.NetworkPort{port("TCP-443", 443)}},
+		{Identifier: "ghost", Type: "internal", ServiceRefNamespace: "honey", ServiceRefName: "missing", Ports: []v1beta1.NetworkPort{port("TCP-1", 1)}},
+	}
+	out := ExpandServiceNeighbors(in, l)
+
+	if len(out) != 1 {
+		t.Fatalf("expected 1 synthesized neighbor (alertmanager only), got %d", len(out))
+	}
+	got := out[0]
+	if got.Identifier != "am-resolved" {
+		t.Errorf("identifier: got %q", got.Identifier)
+	}
+	// ClusterIP + both endpoints, port carried over.
+	wantIPs := map[string]bool{"10.43.54.190": false, "10.42.0.44": false, "10.42.0.84": false}
+	for _, ip := range got.IPAddresses {
+		if _, ok := wantIPs[ip]; !ok {
+			t.Errorf("unexpected resolved IP %s", ip)
+		}
+		wantIPs[ip] = true
+	}
+	for ip, seen := range wantIPs {
+		if !seen {
+			t.Errorf("missing resolved IP %s", ip)
+		}
+	}
+	if len(got.Ports) != 1 || got.Ports[0].Port == nil || *got.Ports[0].Port != 9093 {
+		t.Errorf("ports not carried over: %+v", got.Ports)
+	}
+}
+
+// TestExpandServiceNeighbors_HostEntity: fromEntity host resolves to node +
+// gateway IPs on the health port.
+func TestExpandServiceNeighbors_HostEntity(t *testing.T) {
+	l := realFluxTopology()
+	in := []v1beta1.NetworkNeighbor{
+		{Identifier: "probes", Type: "internal", Entity: "host", Ports: []v1beta1.NetworkPort{port("TCP-9440", 9440)}},
+	}
+	out := ExpandServiceNeighbors(in, l)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 synthesized host neighbor, got %d", len(out))
+	}
+	// Feed the synthesized entry through the address matcher the same way the
+	// projection would, to prove end-to-end intent.
+	tuples := Resolve(PeerSpec{Entity: "host", Ports: []PortProto{{Port: 9440, Protocol: "TCP"}}}, l)
+	if !Matches(tuples, "10.42.0.1", 9440, "TCP") {
+		t.Errorf("gateway kubelet probe should match")
+	}
+	if Matches(tuples, "10.42.0.1", 9090, "TCP") {
+		t.Errorf("wrong port must not match")
+	}
+}
+
+// TestExpandServiceNeighbors_Selector: serviceSelector expands across all
+// matching Services in the scoped namespace.
+func TestExpandServiceNeighbors_Selector(t *testing.T) {
+	l := realFluxTopology()
+	in := []v1beta1.NetworkNeighbor{{
+		Identifier:        "guestbooks",
+		Type:              "internal",
+		ServiceSelector:   &metav1.LabelSelector{MatchLabels: map[string]string{"app": "guestbook"}},
+		NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"kubernetes.io/metadata.name": "gitops-demo"}},
+		Ports:             []v1beta1.NetworkPort{port("TCP-80", 80)},
+	}}
+	out := ExpandServiceNeighbors(in, l)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 synthesized neighbor, got %d", len(out))
+	}
+	if len(out[0].IPAddresses) != 2 {
+		t.Errorf("expected 2 guestbook ClusterIPs, got %v", out[0].IPAddresses)
+	}
+}
+
+// TestExpandServiceNeighbors_NilLister: no cluster view, no expansion.
+func TestExpandServiceNeighbors_NilLister(t *testing.T) {
+	in := []v1beta1.NetworkNeighbor{{Identifier: "am", Entity: "host"}}
+	if out := ExpandServiceNeighbors(in, nil); out != nil {
+		t.Errorf("nil lister must expand to nil, got %v", out)
+	}
+}
+
+// TestExpandServiceNeighbors_SelectorFailClosed: a serviceSelector carrying
+// MatchExpressions (unsupported) or an empty matchLabels must NOT broaden the
+// allowlist — it resolves to nothing.
+func TestExpandServiceNeighbors_SelectorFailClosed(t *testing.T) {
+	l := realFluxTopology()
+	cases := []v1beta1.NetworkNeighbor{
+		{Identifier: "expr", ServiceSelector: &metav1.LabelSelector{
+			MatchLabels:      map[string]string{"app": "guestbook"},
+			MatchExpressions: []metav1.LabelSelectorRequirement{{Key: "tier", Operator: metav1.LabelSelectorOpExists}},
+		}, Ports: []v1beta1.NetworkPort{port("TCP-80", 80)}},
+		{Identifier: "empty", ServiceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{}}, Ports: []v1beta1.NetworkPort{port("TCP-80", 80)}},
+	}
+	for _, n := range cases {
+		if out := ExpandServiceNeighbors([]v1beta1.NetworkNeighbor{n}, l); len(out) != 0 {
+			t.Errorf("%s: selector must fail closed, got %d", n.Identifier, len(out))
+		}
+	}
+}
+
+// TestWithResolvedServiceNeighbors: the CP-level wrapper appends resolved
+// neighbors without mutating the input, and is a no-op when nothing resolves.
+func TestWithResolvedServiceNeighbors(t *testing.T) {
+	l := realFluxTopology()
+	cp := &v1beta1.ContainerProfile{}
+	cp.Spec.Egress = []v1beta1.NetworkNeighbor{
+		{Identifier: "am", ServiceRefNamespace: "honey", ServiceRefName: "alertmanager", Ports: []v1beta1.NetworkPort{port("TCP-9093", 9093)}},
+	}
+	cp.Spec.Ingress = []v1beta1.NetworkNeighbor{
+		{Identifier: "probes", Entity: "host", Ports: []v1beta1.NetworkPort{port("TCP-9440", 9440)}},
+	}
+	out := WithResolvedServiceNeighbors(cp, l)
+
+	if len(cp.Spec.Egress) != 1 || len(cp.Spec.Ingress) != 1 {
+		t.Fatalf("input CP must not be mutated: eg=%d in=%d", len(cp.Spec.Egress), len(cp.Spec.Ingress))
+	}
+	if len(out.Spec.Egress) != 2 {
+		t.Errorf("egress: want original + 1 resolved, got %d", len(out.Spec.Egress))
+	}
+	if len(out.Spec.Ingress) != 2 {
+		t.Errorf("ingress: want original + 1 resolved, got %d", len(out.Spec.Ingress))
+	}
+
+	// No-op cases.
+	if got := WithResolvedServiceNeighbors(cp, nil); got != cp {
+		t.Error("nil lister must return the same CP unchanged")
+	}
+	plain := &v1beta1.ContainerProfile{}
+	plain.Spec.Egress = []v1beta1.NetworkNeighbor{{Identifier: "ip", IPAddresses: []string{"10.0.0.0/8"}}}
+	if got := WithResolvedServiceNeighbors(plain, l); got != plain {
+		t.Error("a CP with no service/entity neighbors must return unchanged (same pointer)")
+	}
+}

--- a/pkg/networkpeer/lister.go
+++ b/pkg/networkpeer/lister.go
@@ -1,0 +1,151 @@
+package networkpeer
+
+import (
+	"net"
+
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	discoverylisters "k8s.io/client-go/listers/discovery/v1"
+)
+
+// InformerLister is the production Lister, backed by Service / EndpointSlice /
+// Node informer listers. It resolves a serviceRef/serviceSelector to the
+// Service's ClusterIP(s) ∪ its EndpointSlice addresses, and the "host" entity
+// to every node's InternalIP(s) plus the CNI gateway derived from its PodCIDR.
+type InformerLister struct {
+	services corelisters.ServiceLister
+	slices   discoverylisters.EndpointSliceLister
+	nodes    corelisters.NodeLister
+	// nodeName scopes the "host" entity to the local node. Empty means every
+	// node (used by tests); production passes the agent's own node so kubelet
+	// probes from this node's gateway match without broadening "host" to the
+	// whole cluster.
+	nodeName string
+}
+
+func NewInformerLister(services corelisters.ServiceLister, slices discoverylisters.EndpointSliceLister, nodes corelisters.NodeLister, nodeName string) *InformerLister {
+	return &InformerLister{services: services, slices: slices, nodes: nodes, nodeName: nodeName}
+}
+
+var _ Lister = (*InformerLister)(nil)
+
+func (l *InformerLister) ServiceByName(namespace, name string) (*ServiceInfo, bool) {
+	svc, err := l.services.Services(namespace).Get(name)
+	if err != nil {
+		return nil, false
+	}
+	return l.serviceInfo(svc), true
+}
+
+func (l *InformerLister) ServicesByLabels(serviceSelector, namespaceLabels map[string]string) []*ServiceInfo {
+	// Never resolve an empty selector to labels.Everything() — that would
+	// allowlist every Service in the cluster. Fail closed.
+	if len(serviceSelector) == 0 {
+		return nil
+	}
+	svcs, err := l.services.List(labels.SelectorFromSet(serviceSelector))
+	if err != nil {
+		return nil
+	}
+	wantNS := ""
+	if namespaceLabels != nil {
+		wantNS = namespaceLabels["kubernetes.io/metadata.name"]
+	}
+	var out []*ServiceInfo
+	for _, svc := range svcs {
+		if wantNS != "" && svc.Namespace != wantNS {
+			continue
+		}
+		out = append(out, l.serviceInfo(svc))
+	}
+	return out
+}
+
+func (l *InformerLister) HostIPs() []string {
+	nodes, err := l.nodes.List(labels.Everything())
+	if err != nil {
+		return nil
+	}
+	var ips []string
+	for _, n := range nodes {
+		if l.nodeName != "" && n.Name != l.nodeName {
+			continue
+		}
+		for _, addr := range n.Status.Addresses {
+			if addr.Type == corev1.NodeInternalIP {
+				ips = append(ips, addr.Address)
+			}
+		}
+		for _, cidr := range podCIDRs(n) {
+			if gw := gatewayIP(cidr); gw != "" {
+				ips = append(ips, gw)
+			}
+		}
+	}
+	return dedupe(ips)
+}
+
+func (l *InformerLister) serviceInfo(svc *corev1.Service) *ServiceInfo {
+	info := &ServiceInfo{Namespace: svc.Namespace, Name: svc.Name, Labels: svc.Labels}
+	for _, ip := range svc.Spec.ClusterIPs {
+		if ip != "" && ip != corev1.ClusterIPNone {
+			info.ClusterIPs = append(info.ClusterIPs, ip)
+		}
+	}
+	if len(info.ClusterIPs) == 0 && svc.Spec.ClusterIP != "" && svc.Spec.ClusterIP != corev1.ClusterIPNone {
+		info.ClusterIPs = append(info.ClusterIPs, svc.Spec.ClusterIP)
+	}
+	info.EndpointIPs = l.endpointIPs(svc.Namespace, svc.Name)
+	return info
+}
+
+func (l *InformerLister) endpointIPs(namespace, service string) []string {
+	sel := labels.SelectorFromSet(labels.Set{discoveryv1.LabelServiceName: service})
+	slices, err := l.slices.EndpointSlices(namespace).List(sel)
+	if err != nil {
+		return nil
+	}
+	var ips []string
+	for _, es := range slices {
+		for i := range es.Endpoints {
+			ips = append(ips, es.Endpoints[i].Addresses...)
+		}
+	}
+	return dedupe(ips)
+}
+
+func podCIDRs(n *corev1.Node) []string {
+	if len(n.Spec.PodCIDRs) > 0 {
+		return n.Spec.PodCIDRs
+	}
+	if n.Spec.PodCIDR != "" {
+		return []string{n.Spec.PodCIDR}
+	}
+	return nil
+}
+
+// gatewayIP returns the conventional CNI gateway for a pod CIDR: the network
+// address + 1 (e.g. 10.42.0.0/24 -> 10.42.0.1). Masqueraded node-sourced
+// traffic (kubelet health probes) appears from this address. IPv6 CIDRs yield
+// no gateway (the .1 convention is IPv4).
+func gatewayIP(cidr string) string {
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return ""
+	}
+	ip := ipNet.IP.To4()
+	if ip == nil {
+		return ""
+	}
+	gw := make(net.IP, len(ip))
+	copy(gw, ip)
+	for i := len(gw) - 1; i >= 0; i-- {
+		gw[i]++
+		if gw[i] != 0 {
+			break
+		}
+	}
+	return gw.String()
+}

--- a/pkg/networkpeer/lister_test.go
+++ b/pkg/networkpeer/lister_test.go
@@ -1,0 +1,131 @@
+package networkpeer
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// newTestLister builds an InformerLister over a fake cluster seeded from the
+// real flux/kubescape topology, exercising the production Service/EndpointSlice/
+// Node -> Lister path (not the hand-written fake used by the resolver tests).
+func newTestLister(t *testing.T) *InformerLister {
+	t.Helper()
+	client := fake.NewSimpleClientset(
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "honey", Name: "alertmanager", Labels: map[string]string{"app": "alertmanager"}},
+			Spec:       corev1.ServiceSpec{ClusterIP: "10.43.54.190", ClusterIPs: []string{"10.43.54.190"}},
+		},
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "honey", Name: "alertmanager-x1", Labels: map[string]string{discoveryv1.LabelServiceName: "alertmanager"}},
+			Endpoints:  []discoveryv1.Endpoint{{Addresses: []string{"10.42.0.44", "10.42.0.84"}}},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "gitops-demo", Name: "guestbook-ui", Labels: map[string]string{"app": "guestbook"}},
+			Spec:       corev1.ServiceSpec{ClusterIP: "10.43.111.192", ClusterIPs: []string{"10.43.111.192"}},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "tanzee"},
+			Spec:       corev1.NodeSpec{PodCIDR: "10.42.0.0/24", PodCIDRs: []string{"10.42.0.0/24"}},
+			Status:     corev1.NodeStatus{Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "192.168.0.191"}}},
+		},
+		&corev1.Node{ // a second node whose IPs must NOT leak into this node's "host"
+			ObjectMeta: metav1.ObjectMeta{Name: "other"},
+			Spec:       corev1.NodeSpec{PodCIDR: "10.42.9.0/24", PodCIDRs: []string{"10.42.9.0/24"}},
+			Status:     corev1.NodeStatus{Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "192.168.0.99"}}},
+		},
+	)
+	factory := informers.NewSharedInformerFactory(client, 0)
+	l := NewInformerLister(
+		factory.Core().V1().Services().Lister(),
+		factory.Discovery().V1().EndpointSlices().Lister(),
+		factory.Core().V1().Nodes().Lister(),
+		"tanzee",
+	)
+	stop := make(chan struct{})
+	t.Cleanup(func() { close(stop) })
+	factory.Start(stop)
+	factory.WaitForCacheSync(stop)
+	return l
+}
+
+func TestInformerLister_ServiceByName(t *testing.T) {
+	l := newTestLister(t)
+	svc, ok := l.ServiceByName("honey", "alertmanager")
+	if !ok {
+		t.Fatal("alertmanager Service should resolve")
+	}
+	if len(svc.ClusterIPs) != 1 || svc.ClusterIPs[0] != "10.43.54.190" {
+		t.Errorf("ClusterIPs: got %v", svc.ClusterIPs)
+	}
+	if len(svc.EndpointIPs) != 2 {
+		t.Errorf("EndpointIPs: got %v (want 2 from the EndpointSlice)", svc.EndpointIPs)
+	}
+	// End-to-end through the resolver, like the projection will.
+	tuples := Resolve(PeerSpec{ServiceRef: &ServiceRef{"honey", "alertmanager"}, Ports: []PortProto{{Port: 9093, Protocol: "TCP"}}}, l)
+	if !Matches(tuples, "10.43.54.190", 9093, "TCP") || !Matches(tuples, "10.42.0.44", 9093, "TCP") {
+		t.Errorf("resolver over informer lister should match ClusterIP + endpoints")
+	}
+	if _, ok := l.ServiceByName("honey", "nope"); ok {
+		t.Error("unknown Service must not resolve")
+	}
+}
+
+func TestInformerLister_HostIPs(t *testing.T) {
+	l := newTestLister(t)
+	ips := l.HostIPs()
+	want := map[string]bool{"192.168.0.191": false, "10.42.0.1": false}
+	for _, ip := range ips {
+		if _, ok := want[ip]; ok {
+			want[ip] = true
+		}
+	}
+	for ip, seen := range want {
+		if !seen {
+			t.Errorf("HostIPs missing %s (got %v)", ip, ips)
+		}
+	}
+	for _, ip := range ips {
+		if ip == "192.168.0.99" || ip == "10.42.9.1" {
+			t.Errorf("HostIPs must be scoped to the local node; leaked other node's %s", ip)
+		}
+	}
+}
+
+// TestInformerLister_EmptySelectorFailsClosed: an empty serviceSelector must
+// NOT resolve to every Service in the cluster.
+func TestInformerLister_EmptySelectorFailsClosed(t *testing.T) {
+	l := newTestLister(t)
+	if got := l.ServicesByLabels(map[string]string{}, nil); len(got) != 0 {
+		t.Errorf("empty selector must fail closed, got %d services", len(got))
+	}
+	if got := Resolve(PeerSpec{ServiceSelector: map[string]string{}, Ports: tcp(80)}, l); len(got) != 0 {
+		t.Errorf("Resolve with empty selector must yield nothing, got %v", got)
+	}
+}
+
+func TestInformerLister_ServicesByLabels(t *testing.T) {
+	l := newTestLister(t)
+	svcs := l.ServicesByLabels(map[string]string{"app": "guestbook"}, map[string]string{"kubernetes.io/metadata.name": "gitops-demo"})
+	if len(svcs) != 1 || svcs[0].Name != "guestbook-ui" {
+		t.Fatalf("expected guestbook-ui, got %v", svcs)
+	}
+	// Namespace scoping excludes a same-label service elsewhere (none here) and
+	// a wrong-namespace filter yields nothing.
+	if got := l.ServicesByLabels(map[string]string{"app": "guestbook"}, map[string]string{"kubernetes.io/metadata.name": "other"}); len(got) != 0 {
+		t.Errorf("namespace filter should exclude, got %v", got)
+	}
+}
+
+func TestGatewayIP(t *testing.T) {
+	cases := map[string]string{"10.42.0.0/24": "10.42.0.1", "10.244.5.0/24": "10.244.5.1", "2001:db8::/64": ""}
+	for cidr, want := range cases {
+		if got := gatewayIP(cidr); got != want {
+			t.Errorf("gatewayIP(%s)=%q want %q", cidr, got, want)
+		}
+	}
+}

--- a/pkg/networkpeer/resolve.go
+++ b/pkg/networkpeer/resolve.go
@@ -1,0 +1,192 @@
+// Package networkpeer resolves Kubernetes-native network-neighbor selectors
+// (a Service reference, a Service label selector, or a reserved entity such as
+// "host") into the concrete (IP, port, protocol) tuples an egress/ingress
+// allowlist should match.
+//
+// It exists so a ContainerProfile can express cluster-infrastructure peers —
+// Service ClusterIPs (alertmanager, kube-apiserver via default/kubernetes,
+// kube-dns, ...) and host/kubelet traffic — portably (by name, resolved
+// per-cluster) and narrowly (only the referenced Service/entity), instead of a
+// broad ipAddresses CIDR over the whole service network. See
+// k8sstormcenter/node-agent#92.
+//
+// Resolution is intentionally decoupled from live matching: callers resolve a
+// PeerSpec to []AllowTuple once (e.g. at projection time) via a Lister backed
+// by Service/EndpointSlice/Node informers, then match observed connections
+// against the tuples with Matches. The Lister interface keeps the resolver
+// unit-testable against a fake cluster view.
+package networkpeer
+
+import "strings"
+
+// EntityHost is the reserved entity naming the local node: its InternalIP(s)
+// and the CNI gateway address. It is the one peer class no Service object can
+// represent (kubelet health probes, node-sourced / masqueraded traffic).
+const EntityHost = "host"
+
+// PortProto is a single allowed destination port/protocol. Protocol is
+// upper-case ("TCP"/"UDP"); an empty Protocol matches any protocol.
+type PortProto struct {
+	Port     int32
+	Protocol string
+}
+
+// ServiceRef names a single Service by namespace and name.
+type ServiceRef struct {
+	Namespace string
+	Name      string
+}
+
+// PeerSpec is the storage-agnostic form of one serviceRef / serviceSelector /
+// entity network-neighbor entry. Exactly one of ServiceRef, ServiceSelector,
+// or Entity is expected to be set; Ports scopes the resolved tuples.
+type PeerSpec struct {
+	ServiceRef      *ServiceRef
+	ServiceSelector map[string]string
+	NamespaceLabels map[string]string
+	Entity          string
+	Ports           []PortProto
+}
+
+// ServiceInfo is the resolver's view of one Service.
+type ServiceInfo struct {
+	Namespace   string
+	Name        string
+	Labels      map[string]string
+	ClusterIPs  []string
+	EndpointIPs []string
+}
+
+// Lister is the read-only cluster view the resolver needs. Production wires it
+// to Service/EndpointSlice/Node informer listers; tests use a fake.
+type Lister interface {
+	ServiceByName(namespace, name string) (*ServiceInfo, bool)
+	ServicesByLabels(serviceSelector, namespaceLabels map[string]string) []*ServiceInfo
+	HostIPs() []string
+}
+
+// AllowTuple is one concrete (IP, port, protocol) a resolved PeerSpec permits.
+type AllowTuple struct {
+	IP       string
+	Port     int32
+	Protocol string
+}
+
+// Resolve expands spec into the concrete tuples it authorises, using l for the
+// current cluster view. A spec with no resolvable target (unknown Service,
+// selector matching nothing, unknown entity) yields no tuples — never a
+// match-all. A spec with no Ports yields one tuple per IP with Port 0 /
+// Protocol "" (any-port), so callers that ignore ports still work; callers
+// that enforce ports should treat Port 0 as "unspecified".
+func Resolve(spec PeerSpec, l Lister) []AllowTuple {
+	if l == nil {
+		return nil
+	}
+	ips := resolveIPs(spec, l)
+	if len(ips) == 0 {
+		return nil
+	}
+	return expand(ips, spec.Ports)
+}
+
+// ResolveIPs returns just the IPs a spec resolves to, ignoring ports. Used by
+// the projection-time expansion, which pairs them with the neighbor's own
+// ports.
+func ResolveIPs(spec PeerSpec, l Lister) []string {
+	if l == nil {
+		return nil
+	}
+	return resolveIPs(spec, l)
+}
+
+func resolveIPs(spec PeerSpec, l Lister) []string {
+	switch {
+	case spec.Entity != "":
+		if strings.EqualFold(spec.Entity, EntityHost) {
+			return dedupe(l.HostIPs())
+		}
+		return nil
+	case spec.ServiceRef != nil:
+		svc, ok := l.ServiceByName(spec.ServiceRef.Namespace, spec.ServiceRef.Name)
+		if !ok || svc == nil {
+			return nil
+		}
+		return serviceIPs(svc)
+	case spec.ServiceSelector != nil:
+		// An empty selector is NOT a cluster-wide match-all: fail closed.
+		if len(spec.ServiceSelector) == 0 {
+			return nil
+		}
+		var ips []string
+		for _, svc := range l.ServicesByLabels(spec.ServiceSelector, spec.NamespaceLabels) {
+			ips = append(ips, serviceIPs(svc)...)
+		}
+		return dedupe(ips)
+	default:
+		return nil
+	}
+}
+
+func serviceIPs(svc *ServiceInfo) []string {
+	out := make([]string, 0, len(svc.ClusterIPs)+len(svc.EndpointIPs))
+	out = append(out, svc.ClusterIPs...)
+	out = append(out, svc.EndpointIPs...)
+	return dedupe(out)
+}
+
+func expand(ips []string, ports []PortProto) []AllowTuple {
+	if len(ports) == 0 {
+		out := make([]AllowTuple, 0, len(ips))
+		for _, ip := range ips {
+			out = append(out, AllowTuple{IP: ip})
+		}
+		return out
+	}
+	out := make([]AllowTuple, 0, len(ips)*len(ports))
+	for _, ip := range ips {
+		for _, p := range ports {
+			out = append(out, AllowTuple{IP: ip, Port: p.Port, Protocol: strings.ToUpper(p.Protocol)})
+		}
+	}
+	return out
+}
+
+// Matches reports whether the observed (ip, port, protocol) connection is
+// permitted by any tuple. Matching is port-sensitive: a tuple with Port 0
+// (any-port) matches any observed port; otherwise the port must be equal. An
+// empty tuple Protocol matches any protocol.
+func Matches(tuples []AllowTuple, ip string, port int32, protocol string) bool {
+	protocol = strings.ToUpper(protocol)
+	for _, t := range tuples {
+		if t.IP != ip {
+			continue
+		}
+		if t.Port != 0 && t.Port != port {
+			continue
+		}
+		if t.Protocol != "" && t.Protocol != protocol {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func dedupe(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if s == "" {
+			continue
+		}
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}

--- a/pkg/networkpeer/resolve_test.go
+++ b/pkg/networkpeer/resolve_test.go
@@ -1,0 +1,202 @@
+package networkpeer
+
+import (
+	"sort"
+	"testing"
+)
+
+// fakeLister is a static cluster view seeded from the real Flux/kubescape
+// topology observed on the k3s dev cluster (issue #92). It lets the resolver
+// tests assert against genuine ClusterIPs/endpoints without a live cluster.
+type fakeLister struct {
+	services map[string]*ServiceInfo // key "ns/name"
+	hostIPs  []string
+}
+
+func (f *fakeLister) ServiceByName(ns, name string) (*ServiceInfo, bool) {
+	s, ok := f.services[ns+"/"+name]
+	return s, ok
+}
+
+func (f *fakeLister) ServicesByLabels(sel, nsLabels map[string]string) []*ServiceInfo {
+	var out []*ServiceInfo
+	for _, s := range f.services {
+		if nsLabels != nil {
+			if s.Labels["__ns__"] != nsLabels["kubernetes.io/metadata.name"] {
+				continue
+			}
+		}
+		if labelsSubset(sel, s.Labels) {
+			out = append(out, s)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+func (f *fakeLister) HostIPs() []string { return f.hostIPs }
+
+func labelsSubset(want, have map[string]string) bool {
+	for k, v := range want {
+		if have[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// realFluxTopology mirrors what `kubectl get svc/endpoints` returned live.
+func realFluxTopology() *fakeLister {
+	return &fakeLister{
+		hostIPs: []string{"192.168.0.191", "10.42.0.1"}, // node InternalIP + CNI gateway
+		services: map[string]*ServiceInfo{
+			"honey/alertmanager": {
+				Namespace: "honey", Name: "alertmanager",
+				Labels:      map[string]string{"app": "alertmanager", "__ns__": "honey"},
+				ClusterIPs:  []string{"10.43.54.190"},
+				EndpointIPs: []string{"10.42.0.44", "10.42.0.84"},
+			},
+			"honey/storage": {
+				Namespace: "honey", Name: "storage",
+				Labels:     map[string]string{"app": "storage", "__ns__": "honey"},
+				ClusterIPs: []string{"10.43.70.156"},
+			},
+			"default/kubernetes": { // k3s: apiserver endpoint is the node IP (Kind: Host)
+				Namespace: "default", Name: "kubernetes",
+				Labels:      map[string]string{"__ns__": "default"},
+				ClusterIPs:  []string{"10.43.0.1"},
+				EndpointIPs: []string{"192.168.0.191"},
+			},
+			"argocd/argocd-server": {
+				Namespace: "argocd", Name: "argocd-server",
+				Labels:     map[string]string{"app.kubernetes.io/name": "argocd-server", "__ns__": "argocd"},
+				ClusterIPs: []string{"10.43.173.14"},
+			},
+			"gitops-demo/guestbook-ui": {
+				Namespace: "gitops-demo", Name: "guestbook-ui",
+				Labels:     map[string]string{"app": "guestbook", "__ns__": "gitops-demo"},
+				ClusterIPs: []string{"10.43.111.192"},
+			},
+			"gitops-demo/helm-guestbook": {
+				Namespace: "gitops-demo", Name: "helm-guestbook",
+				Labels:     map[string]string{"app": "guestbook", "__ns__": "gitops-demo"},
+				ClusterIPs: []string{"10.43.3.63"},
+			},
+		},
+	}
+}
+
+func tcp(port int32) []PortProto { return []PortProto{{Port: port, Protocol: "TCP"}} }
+
+// Test A1 — serviceRef egress (alertmanager) is narrow AND port-sensitive:
+// matches its ClusterIP and endpoints on 9093 only; a sibling service on the
+// same port stays visible to R0011 (the whole point vs a /16).
+func TestServiceRef_Alertmanager(t *testing.T) {
+	l := realFluxTopology()
+	tuples := Resolve(PeerSpec{ServiceRef: &ServiceRef{"honey", "alertmanager"}, Ports: tcp(9093)}, l)
+
+	cases := []struct {
+		ip    string
+		port  int32
+		proto string
+		want  bool
+		why   string
+	}{
+		{"10.43.54.190", 9093, "TCP", true, "ClusterIP + port match"},
+		{"10.42.0.44", 9093, "TCP", true, "backing endpoint IP"},
+		{"10.42.0.84", 9093, "TCP", true, "backing endpoint IP"},
+		{"10.43.54.190", 8080, "TCP", false, "wrong port (port-sensitive)"},
+		{"10.43.54.190", 9093, "UDP", false, "wrong protocol"},
+		{"10.43.173.14", 9093, "TCP", false, "argocd-server — different service, detection preserved"},
+		{"10.43.70.156", 9093, "TCP", false, "storage — different service, detection preserved"},
+	}
+	for _, c := range cases {
+		if got := Matches(tuples, c.ip, c.port, c.proto); got != c.want {
+			t.Errorf("Matches(%s:%d/%s)=%v want %v (%s)", c.ip, c.port, c.proto, got, c.want, c.why)
+		}
+	}
+}
+
+// Test A2 — kube-apiserver needs no dedicated entity: toService default/kubernetes
+// resolves to the ClusterIP AND the node-IP endpoint (k3s embeds the apiserver).
+func TestServiceRef_KubeApiserver(t *testing.T) {
+	l := realFluxTopology()
+	tuples := Resolve(PeerSpec{ServiceRef: &ServiceRef{"default", "kubernetes"}, Ports: tcp(443)}, l)
+	for _, ip := range []string{"10.43.0.1", "192.168.0.191"} {
+		if !Matches(tuples, ip, 443, "TCP") {
+			t.Errorf("apiserver egress %s:443 should match via default/kubernetes", ip)
+		}
+	}
+	if Matches(tuples, "10.43.0.1", 6443, "TCP") {
+		t.Errorf("apiserver :6443 must not match (port 443 only)")
+	}
+}
+
+// Test A3 — host entity: kubelet probe from the node/gateway matches on the
+// health port only; a pod-CIDR source or wrong port does not.
+func TestEntityHost(t *testing.T) {
+	l := realFluxTopology()
+	tuples := Resolve(PeerSpec{Entity: EntityHost, Ports: tcp(9440)}, l)
+	if !Matches(tuples, "10.42.0.1", 9440, "TCP") {
+		t.Errorf("kubelet probe 10.42.0.1:9440 should match fromEntity host")
+	}
+	if !Matches(tuples, "192.168.0.191", 9440, "TCP") {
+		t.Errorf("node InternalIP :9440 should match fromEntity host")
+	}
+	if Matches(tuples, "10.42.0.1", 9090, "TCP") {
+		t.Errorf("host :9090 must not match (port 9440 only)")
+	}
+	if Matches(tuples, "10.42.0.55", 9440, "TCP") {
+		t.Errorf("a pod IP must not match fromEntity host")
+	}
+}
+
+// Test A4 — serviceSelector fans out across all matching Services (the two
+// gitops-demo guestbook services share app=guestbook), scoped by namespace.
+func TestServiceSelector_GuestbookFanout(t *testing.T) {
+	l := realFluxTopology()
+	tuples := Resolve(PeerSpec{
+		ServiceSelector: map[string]string{"app": "guestbook"},
+		NamespaceLabels: map[string]string{"kubernetes.io/metadata.name": "gitops-demo"},
+		Ports:           tcp(80),
+	}, l)
+	for _, ip := range []string{"10.43.111.192", "10.43.3.63"} {
+		if !Matches(tuples, ip, 80, "TCP") {
+			t.Errorf("guestbook service %s:80 should match app=guestbook selector", ip)
+		}
+	}
+	if Matches(tuples, "10.43.173.14", 80, "TCP") {
+		t.Errorf("argocd-server must not match app=guestbook selector")
+	}
+}
+
+// Test A5 — no accidental match-all: unknown service, unknown entity, and a
+// selector matching nothing all resolve to zero tuples.
+func TestResolve_NoMatchAll(t *testing.T) {
+	l := realFluxTopology()
+	specs := []PeerSpec{
+		{ServiceRef: &ServiceRef{"honey", "does-not-exist"}, Ports: tcp(443)},
+		{Entity: "world", Ports: tcp(443)},
+		{ServiceSelector: map[string]string{"app": "nope"}, Ports: tcp(443)},
+	}
+	for i, s := range specs {
+		if tuples := Resolve(s, l); len(tuples) != 0 {
+			t.Errorf("spec[%d] should resolve to no tuples, got %d", i, len(tuples))
+		}
+	}
+	if Matches(nil, "10.43.0.1", 443, "TCP") {
+		t.Errorf("nil tuples must never match")
+	}
+}
+
+// Test A6 — a nil Lister and any-port (no Ports) behave safely.
+func TestResolve_Edges(t *testing.T) {
+	if got := Resolve(PeerSpec{Entity: EntityHost}, nil); got != nil {
+		t.Errorf("nil lister must resolve to nil, got %v", got)
+	}
+	l := realFluxTopology()
+	anyPort := Resolve(PeerSpec{ServiceRef: &ServiceRef{"honey", "storage"}}, l)
+	if !Matches(anyPort, "10.43.70.156", 443, "TCP") || !Matches(anyPort, "10.43.70.156", 8443, "TCP") {
+		t.Errorf("a serviceRef with no Ports should match any observed port on its IP")
+	}
+}

--- a/pkg/objectcache/containerprofilecache/containerprofilecache.go
+++ b/pkg/objectcache/containerprofilecache/containerprofilecache.go
@@ -16,6 +16,7 @@ import (
 	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
 	"github.com/kubescape/node-agent/pkg/config"
 	"github.com/kubescape/node-agent/pkg/metricsmanager"
+	"github.com/kubescape/node-agent/pkg/networkpeer"
 	"github.com/kubescape/node-agent/pkg/objectcache"
 	"github.com/kubescape/node-agent/pkg/objectcache/callstackcache"
 	"github.com/kubescape/node-agent/pkg/resourcelocks"
@@ -111,6 +112,10 @@ type ContainerProfileCacheImpl struct {
 	containerLocks *resourcelocks.ResourceLocks
 	storageClient  storage.ProfileClient
 	k8sObjectCache objectcache.K8sObjectCache
+	// serviceLister resolves serviceRef/serviceSelector/entity network
+	// neighbors to concrete IPs at projection time. nil = feature off (the
+	// profile projects unchanged), which is what every unit test leaves it as.
+	serviceLister  networkpeer.Lister
 	metricsManager metricsmanager.MetricsManager
 
 	reconcileEvery    time.Duration
@@ -172,6 +177,13 @@ func NewContainerProfileCache(cfg config.Config, storageClient storage.ProfileCl
 	c.removalPending.Set("", time.Time{})
 	c.removalPending.Delete("")
 	return c
+}
+
+// SetServiceLister installs the cluster view used to resolve
+// serviceRef/serviceSelector/entity network neighbors at projection time. It
+// is optional: when unset the projection leaves such neighbors unresolved.
+func (c *ContainerProfileCacheImpl) SetServiceLister(l networkpeer.Lister) {
+	c.serviceLister = l
 }
 
 // refreshRPC calls fn with a context bounded by c.rpcBudget, enforcing a
@@ -579,9 +591,10 @@ func (c *ContainerProfileCacheImpl) buildEntry(
 	}
 	entry.CallStackTree = tree
 
-	// Project under the current spec.
+	// Project under the current spec, resolving any serviceRef/entity network
+	// neighbors to concrete IPs first.
 	spec := c.snapshotSpec()
-	projected := Apply(spec, userMerged, tree)
+	projected := Apply(spec, networkpeer.WithResolvedServiceNeighbors(userMerged, c.serviceLister), tree)
 	entry.Projected = projected
 	entry.SpecHash = projected.SpecHash
 

--- a/pkg/objectcache/containerprofilecache/reconciler.go
+++ b/pkg/objectcache/containerprofilecache/reconciler.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
 	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
+	"github.com/kubescape/node-agent/pkg/networkpeer"
 	"github.com/kubescape/node-agent/pkg/objectcache"
 	"github.com/kubescape/node-agent/pkg/objectcache/callstackcache"
 	"github.com/kubescape/node-agent/pkg/utils"
@@ -490,7 +491,7 @@ func (c *ContainerProfileCacheImpl) rebuildEntryFromSources(
 	// Project under the current spec.
 	spec := c.snapshotSpec()
 	applyStart := time.Now()
-	projectedCP := Apply(spec, projected, tree)
+	projectedCP := Apply(spec, networkpeer.WithResolvedServiceNeighbors(projected, c.serviceLister), tree)
 	if c.cfg.ProfileProjection.DetailedMetricsEnabled {
 		c.metricsManager.ObserveProjectionApplyDuration(time.Since(applyStart))
 		c.observeMemoryMetrics(projected, projectedCP)

--- a/tests/component_test.go
+++ b/tests/component_test.go
@@ -3962,13 +3962,7 @@ func Test_50_ServiceRefNetworkNeighbor(t *testing.T) {
 	time.Sleep(40 * time.Second)
 
 	apiserverIP := getClusterIP(t, "default", "kubernetes")
-	// The kubescape/storage aggregated-apiserver Service is the unlisted peer:
-	// a real in-cluster service (443, non-DNS) the client is NOT authorised to
-	// reach — the exact case the flux RCA cared about (R0011 must still catch
-	// egress to the storage API). Avoids kube-dns:53, which node-agent tracks as
-	// DNS (R0005), not R0011.
-	storageIP := getClusterIP(t, "kubescape", "storage")
-	t.Logf("apiserver ClusterIP=%s (serviceRef-allowed) | kubescape/storage ClusterIP=%s (unlisted)", apiserverIP, storageIP)
+	t.Logf("apiserver ClusterIP=%s (serviceRef-allowed); unlisted egress target=1.1.1.1:80", apiserverIP)
 
 	// Phase 1 — egress to the apiserver, allowlisted by serviceRef
 	// default/kubernetes. The TCP connect is what R0011 evaluates; -k so curl
@@ -3983,18 +3977,21 @@ func Test_50_ServiceRefNetworkNeighbor(t *testing.T) {
 			"apiserver egress is allowlisted by serviceRef default/kubernetes — R0011 must NOT fire")
 	})
 
-	// Phase 2 — egress to the kubescape/storage Service, a real Service NOT in
-	// the profile. serviceRef is narrow (unlike a /16), so lateral movement is
-	// still detected. The TCP connect is what R0011 evaluates; -k so curl
-	// attempts it despite the self-signed cert.
-	t.Run("unlisted_service_fires_r0011", func(t *testing.T) {
+	// Phase 2 — egress NOT covered by the serviceRef must still fire R0011,
+	// proving serviceRef is a NARROW allowlist (only default/kubernetes), not a
+	// blanket that suppresses everything. Raw-IP egress to 1.1.1.1:80 is the
+	// proven R0011 trigger in this suite (mirrors Test_28c) and is the faithful
+	// analog of the flux RCA, where R0011 fired for the external github egress
+	// the named-service allowlist did not cover.
+	t.Run("uncovered_egress_fires_r0011", func(t *testing.T) {
 		before := countR0011(waitAlerts(t, wl.Namespace))
 		for i := 0; i < 3; i++ {
-			so, se, e := wl.ExecIntoPod([]string{"curl", "-skm", "5", fmt.Sprintf("https://%s:443/healthz", storageIP)}, "curl")
-			t.Logf("curl kubescape/storage (unlisted) → err=%v out=%q stderr=%q", e, so, se)
+			so, se, e := wl.ExecIntoPod([]string{"curl", "-sm", "5", "http://1.1.1.1:80"}, "curl")
+			t.Logf("curl 1.1.1.1 (uncovered) → err=%v out=%q stderr=%q", e, so, se)
 		}
-		alerts := waitAlerts(t, wl.Namespace)
-		assert.Greater(t, countR0011(alerts), before,
-			"egress to the unlisted kubescape/storage Service MUST fire R0011 — detection preserved vs a serviceCIDR allowlist")
+		require.Eventually(t, func() bool {
+			return countR0011(waitAlerts(t, wl.Namespace)) > before
+		}, 3*time.Minute, 15*time.Second,
+			"egress uncovered by serviceRef MUST fire R0011 — serviceRef is narrow, not a blanket allow")
 	})
 }

--- a/tests/component_test.go
+++ b/tests/component_test.go
@@ -3906,3 +3906,88 @@ func Test_49_EphemeralContainerFullTreatment(t *testing.T) {
 		return countRuleAlerts(t, ns.Name, "R0001", "ephcon", "id") > 0
 	}, 2*time.Minute, 10*time.Second, "id was not in the ephemeral container's learned profile — it must fire R0001 (detected + alerted like any other container)")
 }
+
+// Test_37_ServiceRefNetworkNeighbor validates the serviceRef selector end to
+// end (k8sstormcenter/node-agent#92): a workload whose ContainerProfile
+// allowlists egress by Service NAME (default/kubernetes — the apiserver, a
+// service every workload legitimately reaches) must NOT fire R0011 for that
+// egress, while egress to a real but UNLISTED in-cluster Service (kube-dns)
+// MUST still fire R0011. That contrast is the whole point of serviceRef over a
+// broad serviceCIDR ipAddresses entry: a narrow, portable allowlist that does
+// not blind R0011 to lateral movement. No toy target manifests — the peers are
+// the cluster's own infrastructure Services.
+func Test_37_ServiceRefNetworkNeighbor(t *testing.T) {
+	start := time.Now()
+	defer tearDownTest(t, start)
+
+	getClusterIP := func(t *testing.T, ns, name string) string {
+		t.Helper()
+		k := k8sinterface.NewKubernetesApi()
+		svc, err := k.KubernetesClient.CoreV1().Services(ns).Get(context.TODO(), name, metav1.GetOptions{})
+		require.NoError(t, err, "must read %s/%s ClusterIP", ns, name)
+		require.NotEmpty(t, svc.Spec.ClusterIP)
+		return svc.Spec.ClusterIP
+	}
+	countR0011 := func(alerts []testutils.Alert) int {
+		n := 0
+		for _, a := range alerts {
+			if a.Labels["rule_id"] == "R0011" {
+				n++
+			}
+		}
+		return n
+	}
+	waitAlerts := func(t *testing.T, ns string) []testutils.Alert {
+		t.Helper()
+		var alerts []testutils.Alert
+		require.Eventually(t, func() bool {
+			var err error
+			alerts, err = testutils.GetAlerts(ns)
+			return err == nil
+		}, 60*time.Second, 5*time.Second, "must be able to fetch alerts")
+		time.Sleep(10 * time.Second)
+		alerts, _ = testutils.GetAlerts(ns)
+		return alerts
+	}
+
+	ns := testutils.NewRandomNamespace()
+	_ = applyUserDefinedContainerProfile(t, ns.Name, "resources/containerprofile-serviceref-network.yaml")
+
+	wl, err := testutils.NewTestWorkload(ns.Name,
+		path.Join(utils.CurrentDir(), "resources/serviceref-client-deployment.yaml"))
+	require.NoError(t, err)
+	require.NoError(t, wl.WaitForReady(80))
+	// Let node-agent load the bound profile AND sync its Service informer
+	// (serviceRef resolves against live cluster state) before generating traffic.
+	time.Sleep(40 * time.Second)
+
+	apiserverIP := getClusterIP(t, "default", "kubernetes")
+	kubeDNSIP := getClusterIP(t, "kube-system", "kube-dns")
+	t.Logf("apiserver ClusterIP=%s (serviceRef-allowed) | kube-dns ClusterIP=%s (unlisted)", apiserverIP, kubeDNSIP)
+
+	// Phase 1 — egress to the apiserver, allowlisted by serviceRef
+	// default/kubernetes. The TCP connect is what R0011 evaluates; -k so curl
+	// attempts it despite the self-signed cert.
+	t.Run("serviceref_allowed_no_r0011", func(t *testing.T) {
+		for i := 0; i < 3; i++ {
+			so, se, e := wl.ExecIntoPod([]string{"curl", "-skm", "5", fmt.Sprintf("https://%s:443/healthz", apiserverIP)}, "curl")
+			t.Logf("curl apiserver → err=%v out=%q stderr=%q", e, so, se)
+		}
+		alerts := waitAlerts(t, wl.Namespace)
+		assert.Equal(t, 0, countR0011(alerts),
+			"apiserver egress is allowlisted by serviceRef default/kubernetes — R0011 must NOT fire")
+	})
+
+	// Phase 2 — egress to kube-dns, a real Service NOT in the profile. serviceRef
+	// is narrow (unlike a /16), so lateral movement is still detected.
+	t.Run("unlisted_service_fires_r0011", func(t *testing.T) {
+		before := countR0011(waitAlerts(t, wl.Namespace))
+		for i := 0; i < 3; i++ {
+			so, se, e := wl.ExecIntoPod([]string{"curl", "-sm", "3", fmt.Sprintf("http://%s:53", kubeDNSIP)}, "curl")
+			t.Logf("curl kube-dns → err=%v out=%q stderr=%q", e, so, se)
+		}
+		alerts := waitAlerts(t, wl.Namespace)
+		assert.Greater(t, countR0011(alerts), before,
+			"egress to the unlisted kube-dns Service MUST fire R0011 — detection preserved vs a serviceCIDR allowlist")
+	})
+}

--- a/tests/component_test.go
+++ b/tests/component_test.go
@@ -3962,8 +3962,13 @@ func Test_50_ServiceRefNetworkNeighbor(t *testing.T) {
 	time.Sleep(40 * time.Second)
 
 	apiserverIP := getClusterIP(t, "default", "kubernetes")
-	kubeDNSIP := getClusterIP(t, "kube-system", "kube-dns")
-	t.Logf("apiserver ClusterIP=%s (serviceRef-allowed) | kube-dns ClusterIP=%s (unlisted)", apiserverIP, kubeDNSIP)
+	// The kubescape/storage aggregated-apiserver Service is the unlisted peer:
+	// a real in-cluster service (443, non-DNS) the client is NOT authorised to
+	// reach — the exact case the flux RCA cared about (R0011 must still catch
+	// egress to the storage API). Avoids kube-dns:53, which node-agent tracks as
+	// DNS (R0005), not R0011.
+	storageIP := getClusterIP(t, "kubescape", "storage")
+	t.Logf("apiserver ClusterIP=%s (serviceRef-allowed) | kubescape/storage ClusterIP=%s (unlisted)", apiserverIP, storageIP)
 
 	// Phase 1 — egress to the apiserver, allowlisted by serviceRef
 	// default/kubernetes. The TCP connect is what R0011 evaluates; -k so curl
@@ -3978,16 +3983,18 @@ func Test_50_ServiceRefNetworkNeighbor(t *testing.T) {
 			"apiserver egress is allowlisted by serviceRef default/kubernetes — R0011 must NOT fire")
 	})
 
-	// Phase 2 — egress to kube-dns, a real Service NOT in the profile. serviceRef
-	// is narrow (unlike a /16), so lateral movement is still detected.
+	// Phase 2 — egress to the kubescape/storage Service, a real Service NOT in
+	// the profile. serviceRef is narrow (unlike a /16), so lateral movement is
+	// still detected. The TCP connect is what R0011 evaluates; -k so curl
+	// attempts it despite the self-signed cert.
 	t.Run("unlisted_service_fires_r0011", func(t *testing.T) {
 		before := countR0011(waitAlerts(t, wl.Namespace))
 		for i := 0; i < 3; i++ {
-			so, se, e := wl.ExecIntoPod([]string{"curl", "-sm", "3", fmt.Sprintf("http://%s:53", kubeDNSIP)}, "curl")
-			t.Logf("curl kube-dns → err=%v out=%q stderr=%q", e, so, se)
+			so, se, e := wl.ExecIntoPod([]string{"curl", "-skm", "5", fmt.Sprintf("https://%s:443/healthz", storageIP)}, "curl")
+			t.Logf("curl kubescape/storage (unlisted) → err=%v out=%q stderr=%q", e, so, se)
 		}
 		alerts := waitAlerts(t, wl.Namespace)
 		assert.Greater(t, countR0011(alerts), before,
-			"egress to the unlisted kube-dns Service MUST fire R0011 — detection preserved vs a serviceCIDR allowlist")
+			"egress to the unlisted kubescape/storage Service MUST fire R0011 — detection preserved vs a serviceCIDR allowlist")
 	})
 }

--- a/tests/component_test.go
+++ b/tests/component_test.go
@@ -3907,7 +3907,7 @@ func Test_49_EphemeralContainerFullTreatment(t *testing.T) {
 	}, 2*time.Minute, 10*time.Second, "id was not in the ephemeral container's learned profile — it must fire R0001 (detected + alerted like any other container)")
 }
 
-// Test_37_ServiceRefNetworkNeighbor validates the serviceRef selector end to
+// Test_50_ServiceRefNetworkNeighbor validates the serviceRef selector end to
 // end (k8sstormcenter/node-agent#92): a workload whose ContainerProfile
 // allowlists egress by Service NAME (default/kubernetes — the apiserver, a
 // service every workload legitimately reaches) must NOT fire R0011 for that
@@ -3916,7 +3916,7 @@ func Test_49_EphemeralContainerFullTreatment(t *testing.T) {
 // broad serviceCIDR ipAddresses entry: a narrow, portable allowlist that does
 // not blind R0011 to lateral movement. No toy target manifests — the peers are
 // the cluster's own infrastructure Services.
-func Test_37_ServiceRefNetworkNeighbor(t *testing.T) {
+func Test_50_ServiceRefNetworkNeighbor(t *testing.T) {
 	start := time.Now()
 	defer tearDownTest(t, start)
 

--- a/tests/resources/containerprofile-serviceref-network.yaml
+++ b/tests/resources/containerprofile-serviceref-network.yaml
@@ -1,0 +1,48 @@
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: ContainerProfile
+metadata:
+  name: serviceref-overlay
+spec:
+  execs:
+  - path: /bin/sleep
+  - path: /usr/bin/curl
+  syscalls:
+  - socket
+  - connect
+  - sendto
+  - recvfrom
+  - read
+  - write
+  - close
+  - openat
+  - mmap
+  - mprotect
+  - munmap
+  - fcntl
+  - ioctl
+  - poll
+  - epoll_create1
+  - epoll_ctl
+  - epoll_wait
+  - bind
+  - listen
+  - accept4
+  - getsockopt
+  - setsockopt
+  - getsockname
+  - getpid
+  - fstat
+  - rt_sigaction
+  - rt_sigprocmask
+  - writev
+  matchLabels:
+    app: serviceref-client
+  egress:
+  - identifier: apiserver-serviceref
+    type: internal
+    serviceRefNamespace: default
+    serviceRefName: kubernetes
+    ports:
+    - name: TCP-443
+      protocol: TCP
+      port: 443

--- a/tests/resources/serviceref-client-deployment.yaml
+++ b/tests/resources/serviceref-client-deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: serviceref-client
+  name: serviceref-client
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: serviceref-client
+  template:
+    metadata:
+      labels:
+        app: serviceref-client
+        kubescape.io/user-defined-profile: serviceref-overlay
+    spec:
+      containers:
+      - name: curl
+        image: docker.io/curlimages/curl@sha256:08e466006f0860e54fc299378de998935333e0e130a15f6f98482e9f8dab3058
+        command: ["sleep", "infinity"]


### PR DESCRIPTION
## What

Resolves `serviceRef` / `serviceSelector` / `host`-entity network neighbors to concrete IPs at projection time, so a ContainerProfile can allowlist cluster-infra egress/ingress **by Service name** or the **host** entity instead of a broad `ipAddresses` serviceCIDR — which allowlists every ClusterIP on the listed ports and blinds R0011/R0012 to lateral movement. RCA + design: #92.

**Stacked on #90 (upstream #902 peer-selectors)** — base branch `rebase/celnetwork`. Pairs with the storage schema PR **k8sstormcenter/storage#42** (`NetworkNeighbor.{ServiceRef*, ServiceSelector, Entity}`).

## Changes

`pkg/networkpeer` (new, 17 tests):
- `resolve.go` — `serviceRef`/`serviceSelector`/`host` → `(IP,port,proto)` tuples; **empty selector fails closed** (never a cluster-wide match-all).
- `expand.go` — storage `NetworkNeighbor` → selector-free `ipAddresses` neighbors (`ExpandServiceNeighbors`) + `WithResolvedServiceNeighbors` CP wrapper; **fails closed on `MatchExpressions` / empty `matchLabels`**; never mutates the input.
- `lister.go` — `InformerLister` over Service/EndpointSlice/Node listers; ClusterIP ∪ endpoints; `host` = the agent's **own** node InternalIP + CNI gateway (carry-correct).

Wiring: `ContainerProfileCache.SetServiceLister` + `WithResolvedServiceNeighbors` before both `Apply()` projection sites; `cmd/main.go` builds the informer factory (bounded `WaitForCacheSync`) and installs the lister. **nil lister = no-op**, so the existing suite is unaffected.

`go.mod` replaces `kubescape/storage` with `k8sstormcenter/storage@<schema-sha>`; fork CI overrides via `STORAGE_REF`.

## Review-driven hardening (fable pass, see #92)
Fixed before opening: fail-open empty/`MatchExpressions` selectors, `HostIPs` scoped to the local node, `gatewayIP` carry, bounded `WaitForCacheSync`. Storage#42 carries the paired IP-collapse data-loss fix.

## Known follow-ups (tracked in #92)
- Port scoping depends on #85's port-aware matcher (this branch's projection is address-only; the library carries ports forward-compatibly).
- Endpoint-IP staleness needs an informer-event → re-project nudge (ClusterIP, the primary case, is stable).

## Tests
`pkg/networkpeer` 17 cases green; `containerprofilecache` suite unaffected; binary compiles. Component test runs via the fork-ci harness against storage#42's image.
